### PR TITLE
Added CMD_DISCONNECT to API

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -883,6 +883,7 @@ void CMainFrame::OnClose()
     s.WinLircClient.DisConnect();
     s.UIceClient.DisConnect();
 
+    SendAPICommand(CMD_DISCONNECT, L"\0");  // according to CMD_NOTIFYENDOFSTREAM (ctrl+f it here), you're not supposed to send NULL here
     __super::OnClose();
 }
 

--- a/src/mpc-hc/MpcApi.h
+++ b/src/mpc-hc/MpcApi.h
@@ -141,6 +141,8 @@ unsigned int {
     // Par n : active file, -1 if no active file
     CMD_PLAYLIST            = 0x50000006,
 
+    // Send information about mpc closing
+    CMD_DISCONNECT          = 0x5000000B,
 
     // ==== Commands from host to MPC
 


### PR DESCRIPTION
Clean way of informing master that mpc in slave just closed.
Up to now there was no way of telling if it's still alive unless master was doing some kind of periodical asking/checking for window existence.

Yay, finally clean pull request.
