### PR TITLE
 P & S preset rotate and hotkey

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -361,6 +361,7 @@ void CAppSettings::CreateCommands()
     ADDCMD((ID_VIEW_VF_FROMOUTSIDE,               0, FVIRTKEY | FNOINVERT,                    IDS_AG_VIDFRM_OUTSIDE));
     ADDCMD((ID_VIEW_VF_SWITCHZOOM,              'P', FVIRTKEY | FNOINVERT,                    IDS_AG_VIDFRM_SWITCHZOOM));
     ADDCMD((ID_ONTOP_ALWAYS,                    'A', FVIRTKEY | FCONTROL | FNOINVERT,         IDS_AG_ALWAYS_ON_TOP));
+    ADDCMD((ID_PANSCAN_NEXT,                      0, FVIRTKEY | FNOINVERT,                    IDS_AG_NEXT_PNS_PRESET));
     ADDCMD((ID_VIEW_RESET,               VK_NUMPAD5, FVIRTKEY | FNOINVERT,                    IDS_AG_PNS_RESET));
     ADDCMD((ID_VIEW_INCSIZE,             VK_NUMPAD9, FVIRTKEY | FNOINVERT,                    IDS_AG_PNS_INC_SIZE));
     ADDCMD((ID_VIEW_INCWIDTH,            VK_NUMPAD6, FVIRTKEY | FNOINVERT,                    IDS_AG_PNS_INC_WIDTH));

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -322,6 +322,7 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
     ON_COMMAND_RANGE(ID_ASPECTRATIO_START, ID_ASPECTRATIO_END, OnViewAspectRatio)
     ON_UPDATE_COMMAND_UI_RANGE(ID_ASPECTRATIO_START, ID_ASPECTRATIO_END, OnUpdateViewAspectRatio)
     ON_COMMAND(ID_ASPECTRATIO_NEXT, OnViewAspectRatioNext)
+    ON_COMMAND(ID_PANSCAN_NEXT, OnViewPnSNext)
     ON_COMMAND_RANGE(ID_ONTOP_DEFAULT, ID_ONTOP_WHILEPLAYINGVIDEO, OnViewOntop)
     ON_UPDATE_COMMAND_UI_RANGE(ID_ONTOP_DEFAULT, ID_ONTOP_WHILEPLAYINGVIDEO, OnUpdateViewOntop)
     ON_COMMAND(ID_VIEW_OPTIONS, OnViewOptions)
@@ -646,6 +647,7 @@ CMainFrame::CMainFrame()
     , m_pGraphThread(nullptr)
     , m_bOpenedThruThread(false)
     , m_nMenuHideTick(0)
+    , m_iPnS(0)
     , m_bWasSnapped(false)
     , m_nSeekDirection(SEEK_DIRECTION_NONE)
     , m_bIsBDPlay(false)
@@ -6714,12 +6716,17 @@ void CMainFrame::OnViewPanNScan(UINT nID)
 
     int x = 0, y = 0;
     int dx = 0, dy = 0;
+    CString info;
 
     switch (nID) {
         case ID_VIEW_RESET:
             m_ZoomX = m_ZoomY = 1.0;
             m_PosX = m_PosY = 0.5;
             m_AngleX = m_AngleY = m_AngleZ = 0;
+            m_iPnS = 0;
+            info.Format(_T("P & S Reset"));
+            m_OSD.DisplayMessage(OSD_TOPLEFT, info, 3000);
+
             break;
         case ID_VIEW_INCSIZE:
             x = y = 1;
@@ -6877,6 +6884,10 @@ void CMainFrame::OnViewPanNScanPresets(UINT nID)
     m_ZoomY = min(max(m_ZoomY, 0.2), 3);
 
     MoveVideoWindow(true);
+
+    CString info;
+    info.Format(_T("P & S Preset: %s"), str.Mid(0, str.Find(_T(","))));
+    m_OSD.DisplayMessage(OSD_TOPLEFT, info, 3000);
 }
 
 void CMainFrame::OnUpdateViewPanNScanPresets(CCmdUI* pCmdUI)
@@ -6972,6 +6983,16 @@ void CMainFrame::OnViewAspectRatioNext()
     }
 
     OnViewAspectRatio(nID);
+}
+
+void CMainFrame::OnViewPnSNext()
+{
+    if (m_iPnS == AfxGetAppSettings().m_pnspresets.GetCount()) {
+        OnViewPanNScan(ID_VIEW_RESET);
+    } else {
+        OnViewPanNScanPresets(ID_PANNSCAN_PRESETS_START + m_iPnS);
+        m_iPnS += 1;
+    }
 }
 
 void CMainFrame::OnViewOntop(UINT nID)

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -715,6 +715,7 @@ public:
     afx_msg void OnViewAspectRatio(UINT nID);
     afx_msg void OnUpdateViewAspectRatio(CCmdUI* pCmdUI);
     afx_msg void OnViewAspectRatioNext();
+    afx_msg void OnViewPnSNext();
     afx_msg void OnViewOntop(UINT nID);
     afx_msg void OnUpdateViewOntop(CCmdUI* pCmdUI);
     afx_msg void OnViewOptions();
@@ -945,6 +946,7 @@ protected:
     void WTSUnRegisterSessionNotification();
 
     DWORD m_nMenuHideTick;
+    UINT m_iPnS;
     UINT m_nSeekDirection;
 public:
     afx_msg UINT OnPowerBroadcast(UINT nPowerEvent, UINT nEventData);

--- a/src/mpc-hc/mplayerc.rc
+++ b/src/mpc-hc/mplayerc.rc
@@ -2538,6 +2538,7 @@ BEGIN
     IDS_AG_DVD_ROOT_MENU    "DVD Root Menu"
     IDS_MPLAYERC_65         "DVD Subtitle Menu"
     IDS_MPLAYERC_66         "DVD Audio Menu"
+    IDS_AG_NEXT_PNS_PRESET  "PnS Next Preset"
 END
 
 STRINGTABLE

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -1365,6 +1365,7 @@
 #define IDS_RESET_COLOR                 41319
 #define ID_MENU_LANGUAGE                41320
 #define ID_HELP_CHECKFORUPDATE          41321
+#define ID_PANSCAN_NEXT                 41322
 #define IDS_USING_LATEST_STABLE         41322
 #define IDS_USING_NEWER_VERSION         41323
 #define IDS_NEW_UPDATE_AVAILABLE        41324
@@ -1501,6 +1502,7 @@
 #define IDS_PPAGE_CAPTURE_SFG0          57351
 #define IDS_PPAGE_CAPTURE_SFG1          57352
 #define IDS_PPAGE_CAPTURE_SFG2          57353
+#define IDS_AG_NEXT_PNS_PRESET          57354
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
## Reading rotate P & S preset

Discussed at
- https://github.com/mpc-hc/mpc-hc/pull/28#commitcomment-2249146

@Underground78

> Can you explain what it does exactly?

Read three additional PnS parameters from [Settings\PnSPresets], if they are present

I use it for horizontal and vertical flip

```
[Settings\PnSPresets]
Preset0=Horizontal flip,0.500,0.500,1.000,1.000,0,180,0
Preset1=Vertical flip,0.500,0.500,1.000,1.000,180,0,0
```

> I would guess it break old settings

No

> does it mean that this info was saved but never read?

No it's not saved by the P & S dialog because
- it doesn't have fields for those values
## Adding P & S preset toggle key
### Name and position

> rename the key to "PnS Next Preset"

The key

name is "Next PnS Preset" because
- it's consistent with the key "Next AR Preset"

position is near "Next AR Preset" because
- they have a similar purpose of changing a preset

The key is

renamed to "PnS Next Preset" because
- it's consistent with the other "PnS" keys

moved near the other "PnS" keys because
- its function is a PnS function as the other "PnS" keys
### Previous PnS Preset

> why isn't there a "PnS Previous Preset" key?
- it's consistent with "Next AR Preset" because there isn't a "Previous AR Preset" key
- it has limited value because all presets can be accessed with a next button
### Resource

Discussed at https://github.com/mpc-hc/mpc-hc/pull/28#discussion_r2309812

> Don't remove this in the same patch please. It's a leftover on purpose but I'd rather completely remove it from every file than partially

This line shouldn't be kept
- if the resouce file is changed from VS rather than directly

because
- doing so is a manual task after a change in the `String Table → Open` or `Resource Symbols` dialog
## Changing resource file encoding from UCS-2 to ASCII

Discussed at https://github.com/mpc-hc/mpc-hc/pull/28#issuecomment-10992975, https://github.com/mpc-hc/mpc-hc/pull/28#commitcomment-2537152, https://github.com/mpc-hc/mpc-hc/pull/28#issuecomment-12969970

When a UCS-2 file is changed the patch with the change will be binary if one file version (in this case the old) is binary. (Subsequent edits will be from text to text.)

The disadvantage of a binary patch is
- it's larger (it includes the whole file that's changed)
- can't display the difference with git

git create a text patch for UTF-8 and ASCII

Programs that support additional character sets (and therefore don't rely on git to generate the patch) include
- TortoiseGitMerge.exe

> We need UTF-16 for the translations. Does the resource compiler allow us to mix ASCII and UTF-16?
> The resource compiler doesn't work with ASCII

Is there another way to solve the problem?
## Fixing ffmpeg gcc i686-w64 host prefix

This commit is in [mingw](https://github.com/john-peterson/mpc-hc/compare/master...mingw)

It's not merged because
- it's not useful
## Commit message

@jeeb

> summary line … 50 to around 70 characters

I agree that the first line should be a title of this length

> After that … an empty line
> … extra paragraphs …72-75 characters

The author shouldn't create line breaks in the commit message because
- it lets the reader rather than the author decide what the appropriate line length is
- some commit message readers can wrap text
- [this reasoned discussion](https://github.com/torvalds/linux/pull/17#issuecomment-11738817) support that
