### PR TITLE
 Revert a25a9d4: temporary fix for chroma upsampling on AMD. 

### DIFF
--- a/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
@@ -781,7 +781,6 @@ HRESULT CDX9AllocatorPresenter::CreateDevice(CString& _Error)
     m_bFullFloatingPointProcessing = s.m_AdvRendSets.iVMR9FullFloatingPointProcessing && renderersData->m_bFP16Support;
     m_bHalfFloatingPointProcessing = s.m_AdvRendSets.iVMR9HalfFloatingPointProcessing && renderersData->m_bFP16Support && !m_bFullFloatingPointProcessing;
 
-
     // set color formats
     if (m_bFullFloatingPointProcessing) {
         m_SurfaceType = D3DFMT_A32B32G32R32F;
@@ -790,11 +789,7 @@ HRESULT CDX9AllocatorPresenter::CreateDevice(CString& _Error)
     } else if (m_bForceInputHighColorResolution || m_bHighColorResolution) {
         m_SurfaceType = D3DFMT_A2R10G10B10;
     } else {
-        if (m_nPCIVendor == PCIV_ATI) {
-            m_SurfaceType = D3DFMT_X8R8G8B8;
-        } else {
-            m_SurfaceType = D3DFMT_A8R8G8B8;
-        }
+        m_SurfaceType = D3DFMT_A8R8G8B8;
     }
 
     D3DDISPLAYMODEEX DisplayMode;
@@ -1067,7 +1062,6 @@ UINT CDX9AllocatorPresenter::GetAdapter(IDirect3D9* pD3D, bool bGetAdapter)
     }
 
     m_D3D9Device = _T("");
-    m_nPCIVendor = 0;
 
     CRenderersSettings& s = GetRenderersSettings();
     if (bGetAdapter && (pD3D->GetAdapterCount() > 1) && (s.D3D9RenderDevice != _T(""))) {
@@ -1078,7 +1072,6 @@ UINT CDX9AllocatorPresenter::GetAdapter(IDirect3D9* pD3D, bool bGetAdapter)
             if (pD3D->GetAdapterIdentifier(adp, 0, &adapterIdentifier) == S_OK) {
                 if ((::StringFromGUID2(adapterIdentifier.DeviceIdentifier, strGUID, 50) > 0) && (s.D3D9RenderDevice == strGUID)) {
                     m_D3D9Device = adapterIdentifier.Description;
-                    m_nPCIVendor = adapterIdentifier.VendorId;
                     return  adp;
                 }
             }
@@ -1097,7 +1090,6 @@ UINT CDX9AllocatorPresenter::GetAdapter(IDirect3D9* pD3D, bool bGetAdapter)
                 D3DADAPTER_IDENTIFIER9 adapterIdentifier;
                 if (pD3D->GetAdapterIdentifier(adp, 0, &adapterIdentifier) == S_OK) {
                     m_D3D9Device = adapterIdentifier.Description;
-                    m_nPCIVendor = adapterIdentifier.VendorId;
                 }
             }
             return adp;

--- a/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.h
@@ -25,7 +25,6 @@
 
 #define VMRBITMAP_UPDATE    0x80000000
 #define NB_JITTER           126
-#define PCIV_ATI            0x1002
 
 extern bool g_bNoDuration;
 extern bool g_bExternalSubtitleTime;
@@ -290,7 +289,6 @@ namespace DSObjects
         CString                 m_strStatsMsg[10];
 
         CString                 m_D3D9Device;
-        DWORD                   m_nPCIVendor;
 
         CString                 m_Decoder;
 


### PR DESCRIPTION
Hi,
I think we should revert this "temporary fix" and use the same surface for all vendors for consistency. 

I was affected back then, I even wrote about the problem on doom9. But now everything works fine. I did test on 12.10 (WHQL) and 12.11 (Beta11) drivers and the problem apparently was fixed.  No need to keep workarounds when they are not needed.

Regards
