### PR TITLE
webui: url decode POST values; fix seeking

### DIFF
--- a/src/mpc-hc/WebClientSocket.cpp
+++ b/src/mpc-hc/WebClientSocket.cpp
@@ -283,7 +283,7 @@ void CWebClientSocket::ParsePostData()
         val.SetString(start, int(end - start));
         start = end + 1;
 
-        m_post[key.MakeLower()] = val;
+        m_post[key.MakeLower()] = UTF8To16(UrlDecode(val));
     }
 
     m_parsingState = PARSING_DONE;


### PR DESCRIPTION
In the webui, I noticed the seeking wasn't working correctly, it would always seek to 3 minutes and some seconds, regardless of the video.

I took a look at `CWebClientSocket::OnCommand` in `WebClientSocket.cpp` which handles the seeking and I noticed it was parsing the `position` parameter as if it were already url decoded, but in fact it wasn't.

I changed the parsing to take into account the url encoded colons (`%3A`), it still supports the optional milliseconds parameter. I also did away with the `TCHAR c` variable which was used as a placeholder to parse the colons.

This is my first contribution, so let me know if there's something I should do differently.
