### PR TITLE
DVB Header information for video streams

### DIFF
--- a/src/DSUtil/Mpeg2Def.h
+++ b/src/DSUtil/Mpeg2Def.h
@@ -1,5 +1,5 @@
 /*
- * (C) 2009-2012 see Authors.txt
+ * (C) 2009-2013 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -145,6 +145,7 @@ enum MPEG2_DESCRIPTOR {
     DT_DATA_BROADCAST_ID        = 0x66,
     DT_AC3_AUDIO                = 0x6a,     // DVB
     DT_EXTENDED_AC3_AUDIO       = 0x7a,
+    DT_AAC_AUDIO                = 0x7c,
     //
     DT_AC3_AUDIO__2             = 0x81,     // DCII ou ATSC
     DT_LOGICAL_CHANNEL          = 0x83,

--- a/src/mpc-hc/DVBChannel.cpp
+++ b/src/mpc-hc/DVBChannel.cpp
@@ -36,6 +36,11 @@ CDVBChannel::CDVBChannel()
     , m_ulPCR(0)
     , m_ulVideoPID(0)
     , m_nVideoType(DVB_MPV)
+    , m_nVideoFps(DVB_FPS_25_0)
+    , m_nVideoChroma(DVB_Chroma_4_2_0)
+    , m_nVideoWidth(0)
+    , m_nVideoHeight(0)
+    , m_nVideoAR(DVB_AR_NULL)
     , m_nAudioCount(0)
     , m_nDefaultAudio(0)
     , m_nSubtitleCount(0)
@@ -69,7 +74,7 @@ void CDVBChannel::FromString(CString strValue)
     m_ulPMT       = _tstol(strValue.Tokenize(_T("|"), i));
     m_ulPCR       = _tstol(strValue.Tokenize(_T("|"), i));
     m_ulVideoPID  = _tstol(strValue.Tokenize(_T("|"), i));
-    m_nVideoType  = (DVB_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+    m_nVideoType  = (DVB_STREAM_TYPE) _tstol(strValue.Tokenize(_T("|"), i));
     m_nAudioCount = _tstol(strValue.Tokenize(_T("|"), i));
     if (nVersion > FORMAT_VERSION_1) {
         m_nDefaultAudio = _tstol(strValue.Tokenize(_T("|"), i));
@@ -92,12 +97,20 @@ void CDVBChannel::FromString(CString strValue)
         m_Subtitles[j].PesType = (PES_STREAM_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
         m_Subtitles[j].Language = strValue.Tokenize(_T("|"), i);
     }
+    if (nVersion > FORMAT_VERSION_3) {
+        m_nVideoFps  = (DVB_FPS_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoChroma = (DVB_CHROMA_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoWidth = _tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoHeight = _tstol(strValue.Tokenize(_T("|"), i));
+        m_nVideoAR = (DVB_AspectRatio_TYPE)_tstol(strValue.Tokenize(_T("|"), i));
+    }
+
 }
 
 CString CDVBChannel::ToString()
 {
     CString strValue;
-    strValue.AppendFormat(_T("%d|%s|%ld|%d|%d|%d|%d|%ld|%ld|%ld|%ld|%ld|%ld|%d|%ld|%d|%ld|%d"),
+    strValue.AppendFormat(_T("%d|%s|%ld|%d|%d|%d|%d|%ld|%ld|%ld|%ld|%ld|%ld|%ld|%d|%ld|%d|%d"),
                           FORMAT_VERSION_CURRENT,
                           m_strName,
                           m_ulFrequency,
@@ -118,13 +131,25 @@ CString CDVBChannel::ToString()
                           m_nDefaultSubtitle);
 
     for (int i = 0; i < m_nAudioCount; i++) {
+        if (m_Audios[i].Language.GetLength() == 0) {
+            m_Audios[i].Language = " ";
+        }
         strValue.AppendFormat(_T("|%ld|%d|%d|%s"), m_Audios[i].PID, m_Audios[i].Type, m_Audios[i].PesType, m_Audios[i].Language);
     }
 
     for (int i = 0; i < m_nSubtitleCount; i++) {
+        if (m_Subtitles[i].Language.GetLength() == 0) {
+            m_Subtitles[i].Language = " ";
+        }
         strValue.AppendFormat(_T("|%ld|%d|%d|%s"), m_Subtitles[i].PID, m_Subtitles[i].Type, m_Subtitles[i].PesType, m_Subtitles[i].Language);
     }
 
+    strValue.AppendFormat(_T("|%d|%d|%ld|%ld|%d"),
+                          m_nVideoFps,
+                          m_nVideoChroma,
+                          m_nVideoWidth,
+                          m_nVideoHeight,
+                          m_nVideoAR);
     return strValue;
 }
 
@@ -132,6 +157,9 @@ void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_T
 {
     switch (nType) {
         case DVB_MPV:
+            m_ulVideoPID = ulPID;
+            m_nVideoType = nType;
+            break;
         case DVB_H264:
             m_ulVideoPID = ulPID;
             m_nVideoType = nType;
@@ -139,6 +167,15 @@ void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_T
         case DVB_MPA:
         case DVB_AC3:
         case DVB_EAC3:
+            if (m_nAudioCount < DVB_MAX_AUDIO) {
+                m_Audios[m_nAudioCount].PID = ulPID;
+                m_Audios[m_nAudioCount].Type = nType;
+                m_Audios[m_nAudioCount].PesType = nPesType;
+                m_Audios[m_nAudioCount].Language = strLanguage;
+                m_nAudioCount++;
+            }
+            break;
+        case DVB_LATM:
             if (m_nAudioCount < DVB_MAX_AUDIO) {
                 m_Audios[m_nAudioCount].PID = ulPID;
                 m_Audios[m_nAudioCount].Type = nType;
@@ -157,4 +194,121 @@ void CDVBChannel::AddStreamInfo(ULONG ulPID, DVB_STREAM_TYPE nType, PES_STREAM_T
             }
             break;
     }
+}
+
+REFERENCE_TIME CDVBChannel::GetAvgTimePerFrame()
+{
+    REFERENCE_TIME Value;
+    switch (m_nVideoFps) {
+        case DVB_FPS_23_976:
+            Value = 417084;
+            break;
+        case DVB_FPS_24_0:
+            Value = 416667;
+            break;
+        case DVB_FPS_25_0:
+            Value = 400000;
+            break;
+        case DVB_FPS_29_97:
+            Value = 333667;
+            break;
+        case DVB_FPS_30_0:
+            Value = 333333;
+            break;
+        case DVB_FPS_50_0:
+            Value = 200000;
+            break;
+        case DVB_FPS_59_94:
+            Value = 166834;
+            break;
+        case DVB_FPS_60_0:
+            Value = 166667;
+            break;
+        default:
+            Value = 0;
+            break;
+    }
+    return Value;
+}
+
+CString CDVBChannel::GetVideoFpsDesc()
+{
+    CString strValue;
+    switch (m_nVideoFps) {
+        case DVB_FPS_23_976:
+            strValue = _T("23.976");
+            break;
+        case DVB_FPS_24_0:
+            strValue = _T("24.000");
+            break;
+        case DVB_FPS_25_0:
+            strValue = _T("25.000");
+            break;
+        case DVB_FPS_29_97:
+            strValue = _T("29.970");
+            break;
+        case DVB_FPS_30_0:
+            strValue = _T("30.000");
+            break;
+        case DVB_FPS_50_0:
+            strValue = _T("50.000");
+            break;
+        case DVB_FPS_59_94:
+            strValue = _T("59.940");
+            break;
+        case DVB_FPS_60_0:
+            strValue = _T("60.000");
+            break;
+        default:
+            strValue = _T("     -");
+            break;
+    }
+    return strValue;
+
+}
+
+DWORD CDVBChannel::GetVideoARx()
+{
+    DWORD Value;
+    switch (GetVideoAR()) {
+        case DVB_AR_1:
+            Value = 1;
+            break;
+        case DVB_AR_3_4:
+            Value = 4;
+            break;
+        case DVB_AR_9_16:
+            Value = 16;
+            break;
+        case DVB_AR_1_2_21:
+            Value = 221;
+            break;
+        default:
+            Value = 0;
+            break;
+    }
+    return Value;
+}
+
+DWORD CDVBChannel::GetVideoARy()
+{
+    DWORD Value;
+    switch (GetVideoAR()) {
+        case DVB_AR_1:
+            Value = 1;
+            break;
+        case DVB_AR_3_4:
+            Value = 3;
+            break;
+        case DVB_AR_9_16:
+            Value = 9;
+            break;
+        case DVB_AR_1_2_21:
+            Value = 100;
+            break;
+        default:
+            Value = 0;
+            break;
+    }
+    return Value;
 }

--- a/src/mpc-hc/DVBChannel.h
+++ b/src/mpc-hc/DVBChannel.h
@@ -23,7 +23,8 @@
 #define FORMAT_VERSION_0       0
 #define FORMAT_VERSION_1       1
 #define FORMAT_VERSION_2       2
-#define FORMAT_VERSION_CURRENT 3
+#define FORMAT_VERSION_3       3
+#define FORMAT_VERSION_CURRENT 4
 
 #define DVB_MAX_AUDIO    10
 #define DVB_MAX_SUBTITLE 10
@@ -46,6 +47,7 @@ enum DVB_STREAM_TYPE {
     DVB_MPA      = 0x02,
     DVB_AC3      = 0x03,
     DVB_EAC3     = 0x04,
+    DVB_LATM     = 0x11,
     DVB_PSI      = 0x80,
     DVB_TIF      = 0x81,
     DVB_EPG      = 0x82,
@@ -53,6 +55,33 @@ enum DVB_STREAM_TYPE {
     DVB_SUB      = 0x83,
     DVB_SUBTITLE = 0xFE,
     DVB_UNKNOWN  = 0xFF
+};
+
+enum DVB_CHROMA_TYPE {
+    DVB_Chroma_NONE = 0x00,
+    DVB_Chroma_4_2_0 = 0x01,
+    DVB_Chroma_4_2_2 = 0x02,
+    DVB_Chroma_4_4_4 = 0x03
+};
+
+enum DVB_FPS_TYPE {
+    DVB_FPS_NONE = 0x00,
+    DVB_FPS_23_976 = 0x01,
+    DVB_FPS_24_0 = 0x02,
+    DVB_FPS_25_0 = 0x03,
+    DVB_FPS_29_97 = 0x04,
+    DVB_FPS_30_0 = 0x05,
+    DVB_FPS_50_0 = 0x06,
+    DVB_FPS_59_94 = 0x07,
+    DVB_FPS_60_0 = 0x08
+};
+
+enum DVB_AspectRatio_TYPE {
+    DVB_AR_NULL = 0x00,
+    DVB_AR_1 = 0x01,
+    DVB_AR_3_4 = 0x02,
+    DVB_AR_9_16 = 0x03,
+    DVB_AR_1_2_21 = 0x04
 };
 
 struct DVBStreamInfo {
@@ -83,6 +112,14 @@ public:
     ULONG GetPMT() const { return m_ulPMT; };
     ULONG GetPCR() const { return m_ulPCR; };
     ULONG GetVideoPID() const { return m_ulVideoPID; };
+    DVB_FPS_TYPE GetVideoFps() const { return m_nVideoFps; }
+    CString GetVideoFpsDesc();
+    DVB_CHROMA_TYPE GetVideoChroma() const { return m_nVideoChroma; }
+    ULONG GetVideoWidth() const {return m_nVideoWidth; }
+    ULONG GetVideoHeight() const {return m_nVideoHeight; }
+    DVB_AspectRatio_TYPE GetVideoAR() {return m_nVideoAR; }
+    DWORD GetVideoARx();
+    DWORD GetVideoARy();
     DVB_STREAM_TYPE GetVideoType() const { return m_nVideoType; }
     ULONG GetDefaultAudioPID() const { return m_Audios[GetDefaultAudio()].PID; };
     DVB_STREAM_TYPE GetDefaultAudioType() const { return m_Audios[GetDefaultAudio()].Type; }
@@ -98,6 +135,7 @@ public:
     bool HasName() const { return !m_strName.IsEmpty(); };
     bool IsEncrypted() const { return m_bEncrypted; };
     bool GetNowNextFlag() const { return m_bNowNextFlag; };
+    REFERENCE_TIME GetAvgTimePerFrame();
 
     void SetName(LPCTSTR Value) { m_strName = Value; };
     void SetFrequency(ULONG Value) { m_ulFrequency = Value; };
@@ -111,6 +149,11 @@ public:
     void SetPMT(ULONG Value) { m_ulPMT = Value; };
     void SetPCR(ULONG Value) { m_ulPCR = Value; };
     void SetVideoPID(ULONG Value) { m_ulVideoPID = Value; };
+    void SetVideoFps(DVB_FPS_TYPE Value) { m_nVideoFps = Value; };
+    void SetVideoChroma(DVB_CHROMA_TYPE Value) { m_nVideoChroma = Value; };
+    void SetVideoWidth(ULONG Value) { m_nVideoWidth = Value; };
+    void SetVideoHeight(ULONG Value) { m_nVideoHeight = Value; };
+    void SetVideoAR(DVB_AspectRatio_TYPE Value) { m_nVideoAR = Value; };
     void SetDefaultAudio(int Value) { m_nDefaultAudio = Value; }
     void SetDefaultSubtitle(int Value) { m_nDefaultSubtitle = Value; }
 
@@ -130,6 +173,11 @@ private:
     ULONG m_ulPCR;
     ULONG m_ulVideoPID;
     DVB_STREAM_TYPE m_nVideoType;
+    DVB_FPS_TYPE m_nVideoFps;
+    DVB_CHROMA_TYPE m_nVideoChroma;
+    ULONG m_nVideoWidth;
+    ULONG m_nVideoHeight;
+    DVB_AspectRatio_TYPE m_nVideoAR;
     int m_nAudioCount;
     int m_nDefaultAudio;
     int m_nSubtitleCount;

--- a/src/mpc-hc/FGManagerBDA.cpp
+++ b/src/mpc-hc/FGManagerBDA.cpp
@@ -42,14 +42,14 @@
 
 
 /// Format, Video MPEG2
-static const MPEG2VIDEOINFO sMpv_fmt = {
+static MPEG2VIDEOINFO sMpv_fmt = {
     {
         // hdr
         {0, 0, 720, 576},           // rcSource
         {0, 0, 0, 0},               // rcTarget
         0,                          // dwBitRate
         0,                          // dwBitErrorRate
-        0,                          // AvgTimePerFrame
+        400000,                     // AvgTimePerFrame
         0,                          // dwInterlaceFlags
         0,                          // dwCopyProtectFlags
         0,                          // dwPictAspectRatioX
@@ -67,7 +67,7 @@ static const MPEG2VIDEOINFO sMpv_fmt = {
 };
 
 /// Media type, Video MPEG2
-static const AM_MEDIA_TYPE mt_Mpv = {
+static AM_MEDIA_TYPE mt_Mpv = {
     MEDIATYPE_Video,                // majortype
     MEDIASUBTYPE_MPEG2_VIDEO,       // subtype
     FALSE,                          // bFixedSizeSamples
@@ -82,7 +82,7 @@ static const AM_MEDIA_TYPE mt_Mpv = {
 #define FCC_h264 MAKEFOURCC('h', '2', '6', '4')
 
 /// Format, Video H264
-static const VIDEOINFOHEADER2 vih2_H264 = {
+static VIDEOINFOHEADER2 vih2_H264 = {
     {0, 0, 0, 0},                   // rcSource
     {0, 0, 0, 0},                   // rcTarget
     0,                              // dwBitRate,
@@ -109,7 +109,7 @@ static const VIDEOINFOHEADER2 vih2_H264 = {
 };
 
 /// Media type, Video H264
-static const AM_MEDIA_TYPE mt_H264 = {
+static AM_MEDIA_TYPE mt_H264 = {
     MEDIATYPE_Video,                // majortype
     MEDIASUBTYPE_H264,              // subtype
     FALSE,                          // bFixedSizeSamples
@@ -248,6 +248,15 @@ CFGManagerBDA::CFGManagerBDA(LPCTSTR pName, LPUNKNOWN pUnk, HWND hWnd)
 {
     LOG(_T("\n"));
     LOG(_T("Starting session ------------------------------------------------->"));
+    CAppSettings& s = AfxGetAppSettings();
+    CDVBChannel* pChannel = s.FindChannelByPref(s.nDVBLastChannel);
+    if (pChannel) {
+        if (pChannel->GetVideoType() == DVB_H264) {
+            UpdateMediaType(&vih2_H264, pChannel);
+        } else if (pChannel->GetVideoType() == DVB_MPV) {
+            UpdateMediaType(&sMpv_fmt.hdr, pChannel);
+        }
+    }
     m_DVBStreams[DVB_MPV]  = CDVBStream(L"mpv",  &mt_Mpv);
     m_DVBStreams[DVB_H264] = CDVBStream(L"h264", &mt_H264);
     m_DVBStreams[DVB_MPA]  = CDVBStream(L"mpa",  &mt_Mpa);
@@ -264,8 +273,13 @@ CFGManagerBDA::CFGManagerBDA(LPCTSTR pName, LPUNKNOWN pUnk, HWND hWnd)
         m_DVBStreams[DVB_SUB] = CDVBStream(L"sub", &mt_Subtitle, false, MEDIA_TRANSPORT_PAYLOAD);
     }
 
-    m_nCurVideoType = DVB_MPV;
-    m_nCurAudioType = DVB_MPA;
+    if (pChannel) {
+        m_nCurVideoType = pChannel->GetVideoType();
+        m_nCurAudioType = pChannel->GetDefaultAudioType();
+    } else {
+        m_nCurVideoType = DVB_MPV;
+        m_nCurAudioType = DVB_MPA;
+    }
     m_fHideWindow = false;
     m_fSetChannelActive = false;
 
@@ -288,7 +302,8 @@ CFGManagerBDA::CFGManagerBDA(LPCTSTR pName, LPUNKNOWN pUnk, HWND hWnd)
 CFGManagerBDA::~CFGManagerBDA()
 {
     m_DVBStreams.RemoveAll();
-    LOG(_T("\nCFGManagerBDA object destroyed."));
+    LOG(_T("CFGManagerBDA object destroyed."));
+    LOG(_T("\n"));
 }
 
 HRESULT CFGManagerBDA::CreateKSFilter(IBaseFilter** ppBF, CLSID KSCategory, const CStringW& DisplayName)
@@ -428,13 +443,13 @@ STDMETHODIMP CFGManagerBDA::RenderFile(LPCWSTR lpcwstrFile, LPCWSTR lpcwstrPlayL
         return hr;
     }
 
-    CComPtr<IBaseFilter> pMpeg2Demux;
-    if (FAILED(pMpeg2Demux.CoCreateInstance(CLSID_MPEG2Demultiplexer, NULL, CLSCTX_INPROC_SERVER))) {
+    //    CComPtr<IBaseFilter> pMpeg2Demux;
+    if (FAILED(m_pDemux.CoCreateInstance(CLSID_MPEG2Demultiplexer, NULL, CLSCTX_INPROC_SERVER))) {
         MessageBox(AfxGetMyApp()->GetMainWnd()->m_hWnd, ResStr(IDS_BDA_ERROR_DEMULTIPLEXER), ResStr(IDS_BDA_ERROR), MB_ICONERROR | MB_OK);
         TRACE(_T("BDA: Microsoft demux creation: 0x%08x\n"), hr);
     }
-    CheckNoLog(AddFilter(pMpeg2Demux, _T("MPEG-2 Demultiplexer")));
-    if (FAILED(ConnectFilters(pTuner, pMpeg2Demux))) { // Separate receiver is required
+    CheckNoLog(AddFilter(m_pDemux, _T("MPEG-2 Demultiplexer")));
+    if (FAILED(ConnectFilters(pTuner, m_pDemux))) { // Separate receiver is required
         if (FAILED(hr = CreateKSFilter(&pReceiver, KSCATEGORY_BDA_RECEIVER_COMPONENT,  s.strBDAReceiver))) {
             MessageBox(AfxGetMyApp()->GetMainWnd()->m_hWnd, ResStr(IDS_BDA_ERROR_CREATE_RECEIVER), ResStr(IDS_BDA_ERROR), MB_ICONERROR | MB_OK);
             TRACE(_T("BDA: Receiver creation: 0x%08x\n"), hr);
@@ -445,7 +460,7 @@ STDMETHODIMP CFGManagerBDA::RenderFile(LPCWSTR lpcwstrFile, LPCWSTR lpcwstrPlayL
             TRACE(_T("BDA: Tuner <-> Receiver: 0x%08x\n"), hr);
             return hr;
         }
-        if (FAILED(ConnectFilters(pReceiver, pMpeg2Demux))) {
+        if (FAILED(ConnectFilters(pReceiver, m_pDemux))) {
             MessageBox(AfxGetMyApp()->GetMainWnd()->m_hWnd, ResStr(IDS_BDA_ERROR_DEMULTIPLEXER), ResStr(IDS_BDA_ERROR), MB_ICONERROR | MB_OK);
             TRACE(_T("BDA: Receiver <-> Demux: 0x%08x\n"), hr);
             return hr;
@@ -456,7 +471,7 @@ STDMETHODIMP CFGManagerBDA::RenderFile(LPCWSTR lpcwstrFile, LPCWSTR lpcwstrPlayL
         LOG(_T("Network -> Receiver connected."));
     }
 
-    CheckNoLog(CreateMicrosoftDemux(pMpeg2Demux));
+    CheckNoLog(CreateMicrosoftDemux(m_pDemux));
 
 #ifdef _DEBUG
     LOG(_T("\n"));
@@ -492,6 +507,8 @@ STDMETHODIMP CFGManagerBDA::SetChannel(int nChannelPrefNumber)
 
             if (SUCCEEDED(hr)) {
                 s.nDVBLastChannel = nChannelPrefNumber;
+                m_nCurVideoType = pChannel->GetVideoType();
+                m_nCurAudioType = pChannel->GetDefaultAudioType();
                 LOG(_T("SetChannel %d successful."), nChannelPrefNumber);
             }
         }
@@ -510,6 +527,7 @@ STDMETHODIMP CFGManagerBDA::SetFrequency(ULONG freq)
 {
     HRESULT hr;
     const CAppSettings& s = AfxGetAppSettings();
+    LOG(_T("Mapped PID MPEG-2: %d, Mapped PID H.264: %d."), m_DVBStreams[DVB_MPV].GetMappedPID(), m_DVBStreams[DVB_H264].GetMappedPID());
     LOG(_T("SetFrequency to %d."), freq);
     CheckPointer(m_pBDAControl, E_FAIL);
     CheckPointer(m_pBDAFreq, E_FAIL);
@@ -524,20 +542,52 @@ STDMETHODIMP CFGManagerBDA::SetFrequency(ULONG freq)
     return hr;
 }
 
+HRESULT CFGManagerBDA::ClearMaps()
+{
+    HRESULT hr = S_OK;
+    if (m_DVBStreams[DVB_MPV].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_MPV].Unmap(m_DVBStreams[DVB_MPV].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_H264].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_H264].Unmap(m_DVBStreams[DVB_H264].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_MPA].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_MPA].Unmap(m_DVBStreams[DVB_MPA].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_AC3].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_AC3].Unmap(m_DVBStreams[DVB_AC3].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_EAC3].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_EAC3].Unmap(m_DVBStreams[DVB_EAC3].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_LATM].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_LATM].Unmap(m_DVBStreams[DVB_LATM].GetMappedPID()));
+    }
+    if (m_DVBStreams[DVB_SUB].GetMappedPID()) {
+        CheckNoLog(m_DVBStreams[DVB_SUB].Unmap(m_DVBStreams[DVB_SUB].GetMappedPID()));
+    }
+
+    return hr;
+}
+
 STDMETHODIMP CFGManagerBDA::Scan(ULONG ulFrequency, HWND hWnd)
 {
-    CMpeg2DataParser Parser(m_DVBStreams[DVB_PSI].GetFilter());
+    if (ulFrequency == 0) {
+        ClearMaps();
+    } else {
+        CMpeg2DataParser Parser(m_DVBStreams[DVB_PSI].GetFilter());
 
-    LOG(_T("Scanning frequency %d."), ulFrequency);
-    Parser.ParseSDT(ulFrequency);
-    Parser.ParsePAT();
-    Parser.ParseNIT();
+        LOG(_T("Scanning frequency %d."), ulFrequency);
+        Parser.ParseSDT(ulFrequency);
+        Parser.ParsePAT();
+        Parser.ParseNIT();
 
-    POSITION pos = Parser.Channels.GetStartPosition();
-    while (pos) {
-        CDVBChannel& Channel = Parser.Channels.GetNextValue(pos);
-        if (Channel.HasName()) {
-            ::SendMessage(hWnd, WM_TUNER_NEW_CHANNEL, 0, (LPARAM)(LPCTSTR)Channel.ToString());
+        POSITION pos = Parser.Channels.GetStartPosition();
+        while (pos) {
+            CDVBChannel& Channel = Parser.Channels.GetNextValue(pos);
+            if (Channel.HasName()) {
+                ::SendMessage(hWnd, WM_TUNER_NEW_CHANNEL, 0, (LPARAM)(LPCTSTR)Channel.ToString());
+            }
         }
     }
 
@@ -588,9 +638,16 @@ STDMETHODIMP CFGManagerBDA::Enable(long lIndex, DWORD dwFlags)
             pStreamInfo = pChannel->GetAudio(lIndex);
             pStream = &m_DVBStreams[pStreamInfo->Type];
             if (pStream && pStreamInfo) {
+                if (pStream->GetMappedPID()) {
+                    pStream->Unmap(pStream->GetMappedPID());
+                }
                 nState = GetState();
                 if (m_nCurAudioType != pStreamInfo->Type) {
+                    if (GetState() != State_Stopped) {
+                        ChangeState(State_Stopped);
+                    }
                     SwitchStream(m_nCurAudioType, pStreamInfo->Type);
+                    m_nCurAudioType = pStreamInfo->Type;
                 }
                 pStream->Map(pStreamInfo->PID);
                 ChangeState((FILTER_STATE)nState);
@@ -704,7 +761,7 @@ HRESULT CFGManagerBDA::CreateMicrosoftDemux(CComPtr<IBaseFilter>& pMpeg2Demux)
         DVB_STREAM_TYPE nType = m_DVBStreams.GetNextKey(pos);
         CDVBStream& Stream = m_DVBStreams[nType];
 
-        if (nType != DVB_EPG) { // Hack: DVB_EPG not required
+        if (nType != DVB_EPG) { // DVB_EPG not required
             if (!Stream.GetFindExisting() ||
                     (pPin = FindPin(pMpeg2Demux, PINDIR_OUTPUT, Stream.GetMediaType())) == NULL) {
                 CheckNoLog(pDemux->CreateOutputPin((AM_MEDIA_TYPE*)Stream.GetMediaType(), Stream.GetName(), &pPin));
@@ -719,9 +776,6 @@ HRESULT CFGManagerBDA::CreateMicrosoftDemux(CComPtr<IBaseFilter>& pMpeg2Demux)
                 Stream.SetPin(pPin);
                 LOG(_T("Filter connected to Demux for media type %d."), nType);
             }
-            if (nType == DVB_H264) {
-                m_pPin_h264 = pPin;  // Demux h264 output pin
-            }
         }
     }
 
@@ -733,9 +787,18 @@ HRESULT CFGManagerBDA::SetChannelInternal(CDVBChannel* pChannel)
     HRESULT hr = E_ABORT;
     bool fRadioToTV = false;
 
-    int nState = GetState();
+    ClearMaps();
+    if (GetState() != State_Stopped) {
+        ChangeState(State_Stopped);
+    }
 
     if (pChannel->GetVideoPID() != 0) {
+        if (pChannel->GetVideoType() == DVB_H264) {
+            UpdateMediaType(&vih2_H264, pChannel);
+        } else {
+            UpdateMediaType(&sMpv_fmt.hdr, pChannel);
+        }
+
         CheckNoLog(SwitchStream(m_nCurVideoType, pChannel->GetVideoType()));
         if (m_fHideWindow) {
             fRadioToTV = true;
@@ -747,31 +810,19 @@ HRESULT CFGManagerBDA::SetChannelInternal(CDVBChannel* pChannel)
 
     SwitchStream(m_nCurAudioType, pChannel->GetDefaultAudioType());
 
-    // Re-connection needed for H264 to allow different formats of H264 channels
-    // Makes possible switching between H264 channels of different resolutions
-    // and/or between interlaced and progressive.
-
-    if (m_nCurVideoType == DVB_H264) {
-        CComPtr<IPin> pInPin;
-        m_pPin_h264->ConnectedTo(&pInPin);
-        m_pPin_h264->Disconnect();
-        pInPin->Disconnect();
-        ConnectDirect(m_pPin_h264, pInPin, NULL);
+    if (GetState() == State_Stopped) {
+        ChangeState(State_Running);
     }
 
     CheckNoLog(SetFrequency(pChannel->GetFrequency()));
     if (pChannel->GetVideoPID() != 0) {
-        CheckNoLog(m_DVBStreams[m_nCurVideoType].Map(pChannel->GetVideoPID()));
+        CheckNoLog(m_DVBStreams[pChannel->GetVideoType()].Map(pChannel->GetVideoPID()));
     }
 
-    CheckNoLog(m_DVBStreams[m_nCurAudioType].Map(pChannel->GetDefaultAudioPID()));
+    CheckNoLog(m_DVBStreams[pChannel->GetDefaultAudioType()].Map(pChannel->GetDefaultAudioPID()));
 
     if (pChannel->GetSubtitleCount() > 0) {
         CheckNoLog(m_DVBStreams[DVB_SUB].Map(pChannel->GetDefaultSubtitlePID()));
-    }
-
-    if (GetState() != State_Running) {
-        ChangeState(State_Running);      // (FILTER_STATE)nState);
     }
 
     if (fRadioToTV) {
@@ -785,25 +836,79 @@ HRESULT CFGManagerBDA::SetChannelInternal(CDVBChannel* pChannel)
     return hr;
 }
 
-HRESULT CFGManagerBDA::SwitchStream(DVB_STREAM_TYPE& nOldType, DVB_STREAM_TYPE nNewType)
+HRESULT CFGManagerBDA::SwitchStream(DVB_STREAM_TYPE nOldType, DVB_STREAM_TYPE nNewType)
 {
-    if ((nNewType != nOldType) || (nNewType == DVB_H264)) {
-        CComPtr<IBaseFilter> pFGOld = m_DVBStreams[nOldType].GetFilter();
-        CComPtr<IBaseFilter> pFGNew = m_DVBStreams[nNewType].GetFilter();
-        CComPtr<IPin> pOldOut = GetFirstPin(pFGOld, PINDIR_OUTPUT);
-        CComPtr<IPin> pInPin;
-        CComPtr<IPin> pNewOut = GetFirstPin(pFGNew,  PINDIR_OUTPUT);
-
-        if (GetState() != State_Stopped) {
-            ChangeState(State_Stopped);
+    HRESULT hr = S_OK;
+    CComPtr<IBaseFilter> pFGOld = m_DVBStreams[nOldType].GetFilter();
+    CComPtr<IBaseFilter> pFGNew = m_DVBStreams[nNewType].GetFilter();
+    CComPtr<IPin> pOldOut = GetFirstPin(pFGOld, PINDIR_OUTPUT);
+    CComPtr<IPin> pInPin;
+    pOldOut->ConnectedTo(&pInPin);
+    CComPtr<IPin> pNewOut = GetFirstPin(pFGNew,  PINDIR_OUTPUT);
+    if ((nNewType == DVB_H264) || (nNewType == DVB_MPV)) {
+        CComPtr<IMpeg2Demultiplexer> pDemux;
+        m_pDemux->QueryInterface(IID_IMpeg2Demultiplexer, (void**)&pDemux);
+        hr = Disconnect(pOldOut);
+        hr = Disconnect(pInPin);
+        if (nNewType == DVB_H264) {
+            hr = pDemux->SetOutputPinMediaType(L"h264", const_cast<AM_MEDIA_TYPE*>(&mt_H264));
+        } else {
+            hr = pDemux->SetOutputPinMediaType(L"mpv", const_cast<AM_MEDIA_TYPE*>(&mt_Mpv));
         }
-        pOldOut->ConnectedTo(&pInPin);
+        hr = ConnectDirect(pNewOut, pInPin, NULL);
+        //        nOldType = nNewType;
+
+    } else if (nNewType != nOldType) {
         Disconnect(pOldOut);
         Disconnect(pInPin);
-        ConnectDirect(pNewOut, pInPin, NULL);
-        nOldType = nNewType;
+        hr = ConnectDirect(pNewOut, pInPin, NULL);
+        //        nOldType = nNewType;
     }
-    return S_OK;
+    return hr;
+}
+
+void CFGManagerBDA::UpdateMediaType(VIDEOINFOHEADER2* NewVideoHeader, CDVBChannel* pChannel)
+{
+    NewVideoHeader->AvgTimePerFrame = pChannel->GetAvgTimePerFrame();
+    if ((pChannel->GetVideoFps() == DVB_FPS_25_0) ||
+            (pChannel->GetVideoFps() == DVB_FPS_29_97) ||
+            (pChannel->GetVideoFps() == DVB_FPS_30_0)) {
+        NewVideoHeader->dwInterlaceFlags = AMINTERLACE_IsInterlaced;
+    } else {
+        NewVideoHeader->dwInterlaceFlags = 0;
+    }
+    if ((pChannel->GetVideoARx() != 0) && (pChannel->GetVideoARy() != 0)) {
+        NewVideoHeader->dwPictAspectRatioX = pChannel->GetVideoARx();
+        NewVideoHeader->dwPictAspectRatioY = pChannel->GetVideoARy();
+    } else {
+        NewVideoHeader->dwPictAspectRatioX = 16;
+        NewVideoHeader->dwPictAspectRatioY = 9;
+    }
+
+    if (pChannel->GetVideoHeight()) {
+        NewVideoHeader->bmiHeader.biHeight = pChannel->GetVideoHeight();
+        NewVideoHeader->bmiHeader.biWidth = pChannel->GetVideoWidth();
+    } else if (pChannel->GetVideoType() == DVB_H264) {
+        NewVideoHeader->bmiHeader.biHeight = 1080;   // 1080 was the default before this change (should be 576)
+        NewVideoHeader->bmiHeader.biWidth = 1920;    // 1920 was the default before this change (should be 720;
+    } else {
+        NewVideoHeader->bmiHeader.biHeight = 576;
+        NewVideoHeader->bmiHeader.biWidth = 720;
+    }
+
+    if (NewVideoHeader->dwPictAspectRatioX && NewVideoHeader->dwPictAspectRatioY) {
+        NewVideoHeader->bmiHeader.biWidth = (LONG)(NewVideoHeader->bmiHeader.biHeight * NewVideoHeader->dwPictAspectRatioX / NewVideoHeader->dwPictAspectRatioY);
+    }
+
+    NewVideoHeader->rcSource.top = 0;
+    NewVideoHeader->rcSource.left = 0;
+    NewVideoHeader->rcSource.right = NewVideoHeader->bmiHeader.biWidth;
+    NewVideoHeader->rcSource.bottom = NewVideoHeader->bmiHeader.biHeight;
+    NewVideoHeader->rcTarget.top = 0;
+    NewVideoHeader->rcTarget.left = 0;
+    NewVideoHeader->rcTarget.right = 0;
+    NewVideoHeader->rcTarget.bottom = 0;
+
 }
 
 HRESULT CFGManagerBDA::UpdatePSI(EventDescriptor& NowNext)

--- a/src/mpc-hc/FGManagerBDA.h
+++ b/src/mpc-hc/FGManagerBDA.h
@@ -142,15 +142,17 @@ private:
     CString         m_BDANetworkProvider;
     bool            m_fHideWindow;
     bool            m_fSetChannelActive;
-    CComPtr<IPin>   m_pPin_h264;
+    CComPtr<IBaseFilter> m_pDemux;
 
     HRESULT         CreateKSFilter(IBaseFilter** ppBF, CLSID KSCategory, const CStringW& DisplayName);
     HRESULT         ConnectFilters(IBaseFilter* pOutFiter, IBaseFilter* pInFilter);
     HRESULT         CreateMicrosoftDemux(CComPtr<IBaseFilter>& pMpeg2Demux);
     HRESULT         SetChannelInternal(CDVBChannel* pChannel);
-    HRESULT         SwitchStream(DVB_STREAM_TYPE& nOldType, DVB_STREAM_TYPE nNewType);
+    HRESULT         SwitchStream(DVB_STREAM_TYPE nOldType, DVB_STREAM_TYPE nNewType);
     HRESULT         ChangeState(FILTER_STATE nRequested);
+    HRESULT         ClearMaps();
     FILTER_STATE    GetState();
+    void UpdateMediaType(VIDEOINFOHEADER2* NewVideoHeader, CDVBChannel* pChannel);
 
     template <class ITF>
     HRESULT SearchIBDATopology(const CComPtr<IBaseFilter>& pTuner, CComPtr<ITF>& pItf) {

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -432,7 +432,7 @@ public:
     void CloseMedia();
     void StartTunerScan(CAutoPtr<TunerScanData> pTSD);
     void StopTunerScan();
-    void SetChannel(bool bNewList = true);
+    HRESULT SetChannel(int nChannel);
 
     void AddCurDevToPlaylist();
 
@@ -898,6 +898,8 @@ public:
     bool        m_bToggleShaderScreenSpace;
     bool        m_bInOptions;
     bool        m_bStopTunerScan;
+    bool        m_bLockedZoomVideoWindow;
+    int         m_nLockedZoomVideoWindow;
 
     void        SetLoadState(MPC_LOADSTATE iState);
     void        SetPlayState(MPC_PLAYSTATE iState);

--- a/src/mpc-hc/TunerScanDlg.cpp
+++ b/src/mpc-hc/TunerScanDlg.cpp
@@ -33,7 +33,11 @@ enum TSC_COLUMN {
     TSCC_NAME,
     TSCC_FREQUENCY,
     TSCC_ENCRYPTED,
-    TSCC_CHANNEL
+    TSCC_CHANNEL,
+    TSCC_VIDEO_FORMAT,
+    TSCC_VIDEO_FPS,
+    TSCC_VIDEO_RES,
+    TSCC_VIDEO_AR
 };
 
 // CTunerScanDlg dialog
@@ -64,10 +68,14 @@ BOOL CTunerScanDlg::OnInitDialog()
 
     m_OffsetEditBox.EnableWindow(m_bUseOffset);
 
-    m_ChannelList.InsertColumn(TSCC_NUMBER, ResStr(IDS_DVB_CHANNEL_NUMBER), LVCFMT_LEFT, 50);
-    m_ChannelList.InsertColumn(TSCC_NAME, ResStr(IDS_DVB_CHANNEL_NAME), LVCFMT_LEFT, 250);
-    m_ChannelList.InsertColumn(TSCC_FREQUENCY, ResStr(IDS_DVB_CHANNEL_FREQUENCY), LVCFMT_LEFT, 100);
-    m_ChannelList.InsertColumn(TSCC_ENCRYPTED, ResStr(IDS_DVB_CHANNEL_ENCRYPTION), LVCFMT_LEFT, 80);
+    m_ChannelList.InsertColumn(TSCC_NUMBER, ResStr(IDS_DVB_CHANNEL_NUMBER), LVCFMT_LEFT, 35);
+    m_ChannelList.InsertColumn(TSCC_NAME, ResStr(IDS_DVB_CHANNEL_NAME), LVCFMT_LEFT, 190);
+    m_ChannelList.InsertColumn(TSCC_FREQUENCY, ResStr(IDS_DVB_CHANNEL_FREQUENCY), LVCFMT_LEFT, 65);
+    m_ChannelList.InsertColumn(TSCC_ENCRYPTED, ResStr(IDS_DVB_CHANNEL_ENCRYPTION), LVCFMT_LEFT, 55);
+    m_ChannelList.InsertColumn(TSCC_VIDEO_FORMAT, _T("Format"), LVCFMT_LEFT, 55);
+    m_ChannelList.InsertColumn(TSCC_VIDEO_FPS, _T("FPS"), LVCFMT_LEFT, 50);
+    m_ChannelList.InsertColumn(TSCC_VIDEO_RES, _T("Resolution"), LVCFMT_LEFT, 70);
+    m_ChannelList.InsertColumn(TSCC_VIDEO_AR, _T("Aspect Ratio"), LVCFMT_LEFT, 50);
     m_ChannelList.InsertColumn(TSCC_CHANNEL, _T("Channel"), LVCFMT_LEFT, 0);
 
     m_Progress.SetRange(0, 100);
@@ -121,7 +129,7 @@ void CTunerScanDlg::OnBnClickedSave()
         Channel.SetPrefNumber(i);
         s.m_DVBChannels.AddTail(Channel);
     }
-    ((CMainFrame*)AfxGetMainWnd())->SetChannel();
+    ((CMainFrame*)AfxGetMainWnd())->SetChannel(0);
 
     OnOK();
 }
@@ -152,7 +160,7 @@ void CTunerScanDlg::OnBnClickedCancel()
     if (m_bInProgress) {
         ((CMainFrame*)AfxGetMainWnd())->StopTunerScan();
     }
-    ((CMainFrame*)AfxGetMainWnd())->SetChannel(false);
+    ((CMainFrame*)AfxGetMainWnd())->SetChannel(AfxGetAppSettings().nDVBLastChannel);
 
     OnCancel();
 }
@@ -216,7 +224,24 @@ LRESULT CTunerScanDlg::OnNewChannel(WPARAM wParam, LPARAM lParam)
 
         strTemp = Channel.IsEncrypted() ? ResStr(IDS_DVB_CHANNEL_ENCRYPTED) : ResStr(IDS_DVB_CHANNEL_NOT_ENCRYPTED);
         m_ChannelList.SetItemText(nItem, TSCC_ENCRYPTED, strTemp);
-
+        if (Channel.GetVideoType() == DVB_H264) {
+            strTemp = _T(" H.264");
+        } else if (Channel.GetVideoPID()) {
+            strTemp = _T("MPEG-2");
+        } else {
+            strTemp = _T("   -  ");
+        }
+        m_ChannelList.SetItemText(nItem, TSCC_VIDEO_FORMAT, strTemp);
+        strTemp = Channel.GetVideoFpsDesc();
+        m_ChannelList.SetItemText(nItem, TSCC_VIDEO_FPS, strTemp);
+        if (Channel.GetVideoWidth() || Channel.GetVideoHeight()) {
+            strTemp.Format(_T("%dx%d"), Channel.GetVideoWidth(), Channel.GetVideoHeight());
+        } else {
+            strTemp = _T("   -   ");
+        }
+        m_ChannelList.SetItemText(nItem, TSCC_VIDEO_RES, strTemp);
+        strTemp.Format(_T("%d/%d"), Channel.GetVideoARy(), Channel.GetVideoARx());
+        m_ChannelList.SetItemText(nItem, TSCC_VIDEO_AR, strTemp);
         m_ChannelList.SetItemText(nItem, TSCC_CHANNEL, (LPCTSTR) lParam);
     }
 


### PR DESCRIPTION
Changes:
- Added header information from PMT tables for MPEG-2 and H.264 Streams: (fps, Chroma, resolution, Aspect Ratio). 
- This information is now shown during the scanning process
- Reviewed initial load: The default video and audio format are now taken from the default channel to be tunned (instead of hardcoded MPEG-2)
- Review the switching channel approach to be able to change the header information each time a channel is switched.
- The updated header information includes: AvgTimePerFrame, Aspect Ratio, initial resolution, and interlace flag
- Some additional changes previous to supporting DVB-T2

Known issues:
- The resolution and aspect ratio are not informed according to the DVB specifications in most of the channels. The TARGET_BACKGROUND_GRID descriptor should be mandatory for all resolutions different than 720x576 (for pal). I could only find one multiplex informing that in the PMT. It would be important to find a way for informing that resolution during the scanning process so each time we switch a channel, we start with the correct resolution, instead of changing the screen size two or three times.

Note: this PR is linked to a previously closed one. Check PR #50 for previous discussion.
