### PR TITLE
Ignore coverity files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.sdf
 *.suo
 *.user
+/.cov/*
 /.git-rewrite
 /bin
 /bin12


### PR DESCRIPTION
When using coverity VS plugin, settings are stored inside /.cov/ folder.
