### PR TITLE
Improve handling of UTF-8 subtitles with BOM

### DIFF
--- a/src/Subtitles/TextFile.cpp
+++ b/src/Subtitles/TextFile.cpp
@@ -269,6 +269,7 @@ BOOL CTextFile::ReadString(CStringA& str)
             char c = '?';
 
             if (Utf8::isSingleByte(buffer[0])) { // 0xxxxxxx
+                bValid = true;
                 c = buffer[0] & 0x7f;
             } else if (Utf8::isFirstOfMultibyte(buffer[0])) {
                 int nContinuationBytes = Utf8::continuationBytes(buffer[0]);
@@ -409,6 +410,7 @@ BOOL CTextFile::ReadString(CStringW& str)
             WCHAR c = L'?';
 
             if (Utf8::isSingleByte(buffer[0])) { // 0xxxxxxx
+                bValid = true;
                 c = buffer[0] & 0x7f;
             } else if (Utf8::isFirstOfMultibyte(buffer[0])) {
                 int nContinuationBytes = Utf8::continuationBytes(buffer[0]);


### PR DESCRIPTION
The UTF-8 auto-detection will currently fallback to ASCII/ANSI mode as soon as one invalid UTF-8 character is detected, which can lead to proper UTF-8 files not working, because the creator accidentally mixed a few non-UTF8 character in the file.

Instead, if the file actually has a UTF-8 BOM, don't fallback to ASCII/ANSI, and trust the BOM.

This fixes parsing of subtitles like this:
http://pan.baidu.com/share/link?shareid=421917&uk=3558042035

The subtitles themself are completely UTF-8, however there is two lines of comments in the file which include non-UTF-8 characters.
