### PR TITLE
SubtitleDlDlg: support 'pob' language code for Brazilian Portuguese.

### DIFF
--- a/src/DSUtil/DSUtil.cpp
+++ b/src/DSUtil/DSUtil.cpp
@@ -1664,6 +1664,7 @@ static struct {
     {"Bokmål, Norwegian; Norwegian Bokmål", "nob", "nb"},
     {"Bosnian", "bos", "bs"},
     {"Braj", "bra", ""},
+    {"Brazilian", "pob", "pb"},                 // unofficial codes for Brazilian Portuguese language
     {"Breton", "bre", "br",                     MAKELCID(MAKELANGID(LANG_BRETON, SUBLANG_DEFAULT), SORT_DEFAULT)},
     {"Buginese", "bug", ""},
     {"Bulgarian", "bul", "bg",                  MAKELCID(MAKELANGID(LANG_BULGARIAN, SUBLANG_DEFAULT), SORT_DEFAULT)},


### PR DESCRIPTION
There is no entry for Brazilian Portuguese language in ISO639-2 standard. I forget about this issue when I switched from the table of codes retrieved from OS site to ISO6392ToLanguage function. This patch maps non-iso 'pob' language code to 'Brazilian' language name.
