### PR TITLE
Adding delete file key and playlist context menu option

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -234,6 +234,8 @@ void CAppSettings::CreateCommands()
     ADDCMD((ID_FILE_OPENDVDBD,                  'D', FVIRTKEY | FCONTROL | FNOINVERT,         IDS_AG_OPEN_DVD));
     ADDCMD((ID_FILE_OPENDEVICE,                 'V', FVIRTKEY | FCONTROL | FNOINVERT,         IDS_AG_OPEN_DEVICE));
     ADDCMD((ID_FILE_REOPEN,                     'E', FVIRTKEY | FCONTROL | FNOINVERT,         IDS_AG_REOPEN));
+    ADDCMD((ID_FILE_DELETE,                       0, FVIRTKEY | FNOINVERT,                    IDS_FILE_DELETE));
+    ADDCMD((ID_FILE_RECYCLE,                      0, FVIRTKEY | FNOINVERT,                    IDS_FILE_RECYCLE));
 
     ADDCMD((ID_FILE_SAVE_COPY,                    0, FVIRTKEY | FNOINVERT,                    IDS_AG_SAVE_AS));
     ADDCMD((ID_FILE_SAVE_IMAGE,                 'I', FVIRTKEY | FALT | FNOINVERT,             IDS_AG_SAVE_IMAGE));

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -421,7 +421,7 @@ protected:
     bool m_bWasSnapped;
 
 public:
-    void OpenCurPlaylistItem(REFERENCE_TIME rtStart = 0);
+    bool OpenCurPlaylistItem(REFERENCE_TIME rtStart = 0);
     void OpenMedia(CAutoPtr<OpenMediaData> pOMD);
     void PlayFavoriteFile(CString fav);
     void PlayFavoriteDVD(CString fav);
@@ -482,6 +482,8 @@ public:
     bool DoAfterPlaybackEvent();
     void ParseDirs(CAtlList<CString>& sl);
     bool SearchInDir(bool bDirForward);
+    HRESULT FileDelete(CString file, bool recycle = false);
+    bool OnFileDelete_(bool recycle = false);
 
     virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
     virtual BOOL PreTranslateMessage(MSG* pMsg);
@@ -630,6 +632,8 @@ public:
     afx_msg void OnFileOpendevice();
     afx_msg void OnFileOpenCD(UINT nID);
     afx_msg void OnFileReopen();
+    afx_msg void OnFileDelete();
+    afx_msg void OnFileRecycle();
     afx_msg void OnDropFiles(HDROP hDropInfo); // no menu item
     afx_msg void OnFileSaveAs();
     afx_msg void OnUpdateFileSaveAs(CCmdUI* pCmdUI);
@@ -834,7 +838,7 @@ public:
 
     afx_msg void OnNavigateSkip(UINT nID);
     afx_msg void OnUpdateNavigateSkip(CCmdUI* pCmdUI);
-    afx_msg void OnNavigateSkipFile(UINT nID);
+    afx_msg BOOL OnNavigateSkipFile(UINT nID);
     afx_msg void OnUpdateNavigateSkipFile(CCmdUI* pCmdUI);
     afx_msg void OnNavigateMenu(UINT nID);
     afx_msg void OnUpdateNavigateMenu(CCmdUI* pCmdUI);

--- a/src/mpc-hc/PlayerPlaylistBar.h
+++ b/src/mpc-hc/PlayerPlaylistBar.h
@@ -112,6 +112,7 @@ public:
     void SavePlaylist();
 
     bool SelectFileInPlaylist(LPCTSTR filename);
+    bool RemoveFileInPlaylist(LPCTSTR filename);
 
 protected:
     virtual BOOL PreCreateWindow(CREATESTRUCT& cs);

--- a/src/mpc-hc/mplayerc.rc
+++ b/src/mpc-hc/mplayerc.rc
@@ -2231,6 +2231,7 @@ STRINGTABLE
 BEGIN
     IDD_PPAGEACCELTBL       "Player::Keys"
     IDD_PPAGESUBSTYLE       "Subtitles::Default Style"
+    IDS_FILE_DELETE         "Delete from Disk"
     IDD_PPAGEINTERNALFILTERS "Internal Filters"
     IDD_PPAGELOGO           "Player::Logo"
     IDD_PPAGEOUTPUT         "Playback::Output"
@@ -3310,6 +3311,11 @@ BEGIN
     IDS_OSD_RESET_COLOR     "Color settings restored"
     IDS_OSD_NO_COLORCONTROL "Color control is not supported"
     IDS_BRIGHTNESS_INC      "Brightness increase"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_FILE_RECYCLE        "Move to Recycle Bin"
 END
 
 #endif    // English (United States) resources

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -2,6 +2,7 @@
 // Microsoft Visual C++ generated include file.
 // Used by mplayerc.rc
 //
+#define IDS_FILE_RECYCLE                1
 #define IDR_MAINFRAME                   128
 #define IDR_POPUP                       130
 #define IDR_POPUPMAIN                   133
@@ -339,6 +340,7 @@
 #define IDD_PPAGEEXTERNALFILTERS        10030
 #define IDD_PPAGEACCELTBL               10032
 #define IDD_PPAGESUBSTYLE               10033
+#define IDS_FILE_DELETE                 10034
 #define IDD_PPAGEINTERNALFILTERS        10036
 #define IDD_PPAGELOGO                   10037
 #define IDD_PPAGEOUTPUT                 10039
@@ -680,6 +682,8 @@
 #define ID_VIEW_CM_INTENT_SATURATION    24041
 #define ID_VIEW_CM_INTENT_ABSOLUTECOLORIMETRIC 24042
 #define ID_VIEW_HALFFLOATINGPOINTPROCESSING 24043
+#define ID_FILE_DELETE                  24044
+#define ID_FILE_RECYCLE                 24045
 #define ID_VIEW_TEARING_TEST            32769
 #define ID_SHADERS_TOGGLE               32770
 #define IDS_SHADERS_TOGGLE              32771
@@ -1490,6 +1494,6 @@
 #define _APS_NEXT_RESOURCE_VALUE        20013
 #define _APS_NEXT_COMMAND_VALUE         33449
 #define _APS_NEXT_CONTROL_VALUE         22073
-#define _APS_NEXT_SYMED_VALUE           24044
+#define _APS_NEXT_SYMED_VALUE           24046
 #endif
 #endif


### PR DESCRIPTION
## Adding delete file key and playlist context menu option
### Problem

Deleting a file is slow if there's no
- delete hotkey
- delete option in the playlist

This is especially noticeable if many files are previewed and deleted
### Solution

Create these options because
- that makes it faster to delete a file
- other programs have a similar option, f.e.
  - qBittorrent: "Delete → Also delete the files on the hard disk'"
### Discussion

@XhmikosR

> And as we have already discussed in the past, people didn't like the delete option. Personally, I see when it can be useful, but it's what most people prefer.

The option doesn't lead to accidental deletion because
- the context menu item name "Delete from Disk" and "Move to Recycle Bin" clearly communicate the action and can't easily be confused with "Remove" (from playlist)
- delete require confirmation with a familiar dialog (the system "Delete File" dialog)
- "Move to Recycle Bin" can be undone

> Secondly, there must be a confirmation window when we deal with this stuff and obviously use the recycle bin.

The behavior in my Windows 6,1 environment is
- "Delete from Disk" show the "Are you sure you want to permanently delete this file?" dialog
- "Move to Recycle Bin" show the "Are you sure you want to move this file to the Recycle Bin?" dialog

This [SHFILEOPSTRUCT ](http://msdn.microsoft.com/en-us/library/windows/desktop/bb759795%28v=vs.85%29.aspx) quote

> You must provide a full path to delete the file to the Recycle Bin

and the presence of a `FOF_NOCONFIRMATION` option indicate that the default operation is to show the confirmation dialog. It would be redundant to show an additional confirmation dialog

@Armada651

> If you're just going to point the new OnNavigateSkipFile to NavigateSkipFile then why did you rename it?
> But why did you move that code into a seperate function? All that OnNavigateSkipFile does is call NavigateSkipFile. I see no need for the NavigateSkipFile function, it's code should be moved to the OnNavigateSkipFile function.

Fixed (The reason for this is that I didn't know about ON_COMMAND_EX_RANGE that allow OnNavigateSkipFile to return BOOL)

> I would also like to know whether this deletes a file permanently or only to the recycle bin.

This is answered to another question in this post

@jeeb

> I am not sure if I like the idea of actually removing a file (even if it's just moved to the recycle bin) by pressing the delete key, or selecting the single option from the context menu.
> 
> As an idea, explorer seems to handle two modes of removal with the shift modifier. Normal delete and the context menu option would just remove the file from the playlist, shift+del (and possibly a separate 'Remove and delete file' context menu entry) would then also remove the file (to the recycle bin).

There's not a key to change from because
- the "Options → Player → Keys" item doesn't have a default key
- there's no playlist key connected to 'Delete from disk'

If the suggestion is to add a "shift + del" action to the `CPlayerPlaylistBar` (`CSizingControlBarG`) widget
- write the code for that because because I don't know how that's done
- in this context it can be mentioned that the widget would also benefit from a "ctrl + a" (select all items) and "shift + click" (select multiple items) action

> … (and possibly a separate 'Remove and delete file' context menu entry) would then also remove the file (to the recycle bin).

Fixed by renaming the playlist menu item from "Delete" to "Delete from Disk" and adding a "Delete to Recycle Bin" option
## Resource
### Commit

This commit is in [resource](https://github.com/john-peterson/mpc-hc/compare/master...resource)
### Saving resource files in VS

A preceding commit save the resource description in the VS resource editor because
- when a .rc and .h is saved in the VS resource editor (by adding and removing a "String Table" item from the "String Table → Open" dialog and saving the file) it changes and moves lines, add line breaks and remove comments if the preceding file differ from the VS resouce editor's pattern

which has meaning for a subsequent edit of a constant or string because

editing constants in the VS resource files should be done in the VS resource editor rather than manually because
- adding a constant to the VS  .h resource description manually doesn't automatically increment _APS_NEXT_SYMED_VALUE

editing strings in the VS resource files should be done in the VS resource editor rather than manually because
- it doesn't automatically update the strings's constant to the .h resource description
- opening a .rc for manual editing in VS is more cursor navigation ("double-click" on .rc in VS expand the item in "Resource View" instead of opening the file for manual editing, "right-click View Code" open the file for manual editing)

if manual editing is desired

for constants they should be placed in `enum` because (compared to a manual variable list)
- constants can be organised (moved, added or removed) without requiring a manual value change
- the last item is automatically the total number of items in the group

for strings they should be placed in a .h or .cpp (rather than a .rc) file because
- opening a .h for manual editing in VS is less cursor navigation

@XhmikosR 

> For one the resource files aren't updated.

Which file does this refer to and what should the change be?

The resource entries are created in VS 11 with
- string is added with "Resource View → mplayer.rc → String Table → right-click Open → right-click New String"
- constant is added with "Resource View → mplayer.rc → right-click Resource Symbols → New"

If another method is better describe

for adding a constant
- the constant that should be selected
- the principle by which the constant should be selected

for adding a string
- the line it should be added at
- the principle for selecting which line it should be added at

why this method is better
### Discussion

> We will not merge the resource file changes, as the resource editor produces very dirty patches.

This is a more clear answer to the resource questions because this reply is less clear

> for adding a constant
> - the constant that should be selected
> - the principle by which the constant should be selected

It should be incremental from and after the previously highest value of

```
ID_
IDS_
```

`_APS_NEXT_SYMED_VALUE` isn't necessary if the VS resource editor isn't used because it's a value it uses to select the next constant

> for adding a string
> - the line it should be added at
> - the principle for selecting which line it should be added at

strings are placed after this [mplayerc.rc](https://github.com/mpc-hc/mpc-hc/blob/master/src/mpc-hc/mplayerc.rc)  text

```
/////////////////////////////////////////////////////////////////////////////
//
// String Table
```

and organised according to their kind in `STRINGTABLE` blocks

```
STRINGTABLE
BEGIN
    IDS_                    "Text"
END
```

> why this method is better

The manually (compared to automatic in the VS resource editor) edited resource description is
- better organised
- give more precise control of file content
