### PR TITLE
Improving the single-instance IPC

### DIFF
--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -287,6 +287,7 @@ class CMainFrame : public CFrameWnd, public CDropTarget
 
     LARGE_INTEGER m_liLastSaveTime;
     DWORD m_dwLastRun;
+    DWORD m_dwLastRunWM;
 
     bool m_fBuffering;
 

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -992,7 +992,7 @@ BOOL CMPlayerCApp::InitInstance()
     if (GetLastError() == ERROR_ALREADY_EXISTS &&
             (!(m_s.GetAllowMultiInst() || m_s.nCLSwitches & CLSW_NEW || m_cmdln.IsEmpty()) || m_s.nCLSwitches & CLSW_ADD)) {
 
-        DWORD res = WaitForSingleObject(m_mutexOneInstance.m_h, 5000);
+        DWORD res = WaitForSingleObject(m_mutexOneInstance.m_h, INFINITE);
         if (res == WAIT_OBJECT_0 || res == WAIT_ABANDONED) {
             HWND hWnd = ::FindWindow(MPC_WND_CLASS_NAME, NULL);
             if (hWnd) {


### PR DESCRIPTION
### Problem

Prouce the problem by

enabling the option

* "Options → Player → Use the same player for each media file"

open more than one folder with the command

* `mpc-hc folder1 & mpc-hc folder2` (instead of `mpc-hc folder1 folder2`)


if "folder2" take

* between 0,5 and 5 s to recurse it remove the playlist entries added by "folder1"
* longer than 5 s to recurse it's opened in a new instance



### Example

F.e. XYplorer "File → Open with" use `process folder1 & process folder2` instead of `process folder1 folder2` to open multiple folders



### Solution

Improving the 0,5 s limit by

* counting it from when the previous instance finished rather than started opening

Removing the 5 s limit



### Variable location

The variables are declared near "m_liLastSaveTime" because that's also a field that store time



### Remove message

Removing the line

	 4253               SendMessage(WM_COMMAND, ID_FILE_CLOSEMEDIA);

should be considered because

* it takes around 1,5 s
* its purpose isn't clear



### Other

@XhmikosR

>m_nIPCTick(ULONG_MAX)

>Why do you need to initialize those like that?

These must be initialised because they can be referenced before assignment

m_dwLastRun
m_dwLastRunWM

Because this reasoning appear to be correct the initialisation is changed from "ULONG_MAX" to "0"

>If this is initailised to "0" (instead of "ULONG_MAX") (and "m_VM_Tick" is assigned to "GetTickCount()" before the first WM_COPYDATA) then "m_dwLastRunWM - m_dwLastRun > 500" instead of  "m_dwLastRunWM - m_dwLastRun < 500" resulting in the first instance not adding files to the playlist (the first "OnCopyData" call not assigning "s.nCLSwitches |= CLSW_ADD")

>m_dwLastRun