### PR TITLE
Increase subtitle toggle speed.

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -13871,7 +13871,7 @@ bool CMainFrame::LoadSubtitle(CString fn, ISubStream** actualStream /*= nullptr*
     return !!pSubStream;
 }
 
-bool CMainFrame::SetSubtitle(int i, bool bIsOffset /*= false*/, bool bDisplayMessage /*= false*/, bool bApplyDefStyle /*= false*/)
+bool CMainFrame::SetSubtitle(int i, bool bIsOffset /*= false*/, bool bDisplayMessage /*= false*/, bool bApplyDefStyle /*= false*/, bool bSetSubStream /*= true*/)
 {
     if (!m_pCAP) {
         return false;
@@ -13894,11 +13894,14 @@ bool CMainFrame::SetSubtitle(int i, bool bIsOffset /*= false*/, bool bDisplayMes
             }
             i = 0;
         }
-        {
+
+        if (bSetSubStream) {
             // m_csSubLock shouldn't be locked when using IAMStreamSelect::Enable
             CAutoLock cAutoLock(&m_csSubLock);
             pSubInput->subStream->SetStream(i);
             SetSubtitle(pSubInput->subStream, bApplyDefStyle);
+        } else {
+            m_pCAP->SetSubPicProvider(CComQIPtr<ISubPicProvider>(m_pCurrentSubStream));
         }
 
         if (bDisplayMessage) {
@@ -13998,7 +14001,7 @@ void CMainFrame::ToggleSubtitleOnOff(bool bDisplayMessage /*= false*/)
     s.fEnableSubtitles = !s.fEnableSubtitles;
 
     if (s.fEnableSubtitles) {
-        SetSubtitle(0, true, bDisplayMessage);
+        SetSubtitle(0, true, bDisplayMessage, false, false);
     } else {
         m_pCAP->SetSubPicProvider(nullptr);
 

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -468,7 +468,7 @@ public:
     int SetupSubtitleStreams();
 
     bool LoadSubtitle(CString fn, ISubStream** actualStream = nullptr, bool bAutoLoad = false);
-    bool SetSubtitle(int i, bool bIsOffset = false, bool bDisplayMessage = false, bool bApplyDefStyle = false);
+    bool SetSubtitle(int i, bool bIsOffset = false, bool bDisplayMessage = false, bool bApplyDefStyle = false, bool bSetSubStream = true);
     void SetSubtitle(ISubStream* pSubStream, bool bApplyDefStyle = false);
     void ToggleSubtitleOnOff(bool bDisplayMessage = false);
     void ReplaceSubtitle(const ISubStream* pSubStreamOld, ISubStream* pSubStreamNew);


### PR DESCRIPTION
This pull request addresses [#3650](https://trac.mpc-hc.org/ticket/3650). Turning subtitles on takes up to 3 seconds sometimes on my Intel Atom netbook. It's not fast enough to toggle subs on the fly.

Unfortunately, I'm not that familiar of MPC-HC internals for now. This patch works for me, but I'm not sure I didn't insert a bug. So, its more RFC than actual pull request.
