### PR TITLE
Fix repainting of toolbar separators

### DIFF
--- a/docs/Changelog.txt
+++ b/docs/Changelog.txt
@@ -41,6 +41,7 @@ next version - not released yet
   but it could produce blinking in some cases
 ! Ticket #2588, Subtitle renderer: The subtitle's shadow was not drawn when the subtitle's border was very thin
 ! Ticket #2773, Subtitle renderer: Fix possible artifacts when using karaoke effects
+! Ticket #2994, Fix toolbar separators not being properly painted
 ! Ticket #3437, Audio Switcher: Support fallback to another media type. For example, this enables audio decoders
   to fallback to normal decoding if bitstreaming isn't supported
 ! Ticket #3763, VMR-9 renderless and EVR-CP: The displayed subtitle was not updated when seeking while playback was paused

--- a/src/mpc-hc/PlayerToolBar.cpp
+++ b/src/mpc-hc/PlayerToolBar.cpp
@@ -91,7 +91,12 @@ BOOL CPlayerToolBar::Create(CWnd* pParentWnd)
     };
 
     for (int i = 0; i < _countof(styles); ++i) {
-        SetButtonStyle(i, styles[i] | TBBS_DISABLED);
+        // This fixes missing separator in Win 7
+        if (styles[i] & TBBS_SEPARATOR) {
+            SetButtonInfo(i, GetItemID(i), styles[i], -1);
+        } else {
+            SetButtonStyle(i, styles[i] | TBBS_DISABLED);
+        }
     }
 
     m_volctrl.Create(this);
@@ -306,6 +311,9 @@ void CPlayerToolBar::OnNcPaint() // when using XP styles the NC area isn't drawn
     dc.FillSolidRect(wr, GetSysColor(COLOR_BTNFACE));
 
     // Do not call CToolBar::OnNcPaint() for painting messages
+    
+    // Invalidate window to force repaint the expanded separator
+    Invalidate(FALSE);
 }
 
 BOOL CPlayerToolBar::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)


### PR DESCRIPTION
Fix repainting of toolbar separators after non-client area has been painted.
Fixes #4114 and  #2994
