### PR TITLE
Fix typo in DVB subtitle parser.

### DIFF
--- a/src/Subtitles/DVBSub.cpp
+++ b/src/Subtitles/DVBSub.cpp
@@ -222,18 +222,18 @@ HRESULT CDVBSub::ParseSample(REFERENCE_TIME rtStart, REFERENCE_TIME rtStop, BYTE
             MARKER; // 14..0
             pts = 10000 * pts / 90;
 
-            m_rtStart = pts;
-            m_rtStop = pts + 1;
+            rtStart = pts;
+            rtStop = pts + 1;
         } else {
-            m_rtStart = INVALID_TIME;
-            m_rtStop = INVALID_TIME;
+            rtStart = INVALID_TIME;
+            rtStop = INVALID_TIME;
         }
 
         nLen  -= 14;
         pData += 14;
     }
     m_rtStart = rtStart;
-    m_rtStop = m_rtStop;
+    m_rtStop = rtStop;
 
     hr = AddToBuffer(pData, nLen);
     if (hr == S_OK) {


### PR DESCRIPTION
I haven't test this, but I think this fixes an unintentional "foo = foo" bug on line 236 and restores the use of the computation of m_rtStart from pts.

I suspect there is still an issue with this change. The older version of this file (acb7f94) seemed to use the computation of pts if and only if `pSample->GetTime(...)` and `pSample(GetMediaTime(...)` both failed. As of 733bc17, however, that should never happen as `SubtitleInputPin::Receive(...)` (the only caller of ParseSample I believe) will fail if `GetTime(...)` fails, and so the start and end times passed in to this function are guaranteed to be valid. This means before 733bc17 `m_rtStart = pts` was always getting overwritten a few lines down, and can be removed entirely.

Since I'm not really confident that the above is 100% correct and I don't know how to test this, I'm just submitting the change as is with that somebody more familiar with the code can chime in and point out if I'm wrong or not.
