### PR TITLE
Set the Video Window for EVR before connecting input pins

### DIFF
--- a/src/mpc-hc/FGFilter.cpp
+++ b/src/mpc-hc/FGFilter.cpp
@@ -479,6 +479,13 @@ HRESULT CFGFilterVideoRenderer::Create(IBaseFilter** ppBF, CInterfaceList<IUnkno
         if (m_clsid == CLSID_EnhancedVideoRenderer) {
             CComQIPtr<IEVRFilterConfig> pConfig = pBF;
             pConfig->SetNumberOfStreams(3);
+
+            if (CComQIPtr<IMFGetService> pMFGS = pBF) {
+              CComPtr<IMFVideoDisplayControl> pMFVDC;
+              if (SUCCEEDED(pMFGS->GetService(MR_VIDEO_RENDER_SERVICE, __uuidof(IMFVideoDisplayControl), (void **)&pMFVDC))) {
+                pMFVDC->SetVideoWindow(m_hWnd);
+              }
+            }
         }
 
         BeginEnumPins(pBF, pEP, pPin) {


### PR DESCRIPTION
This allows the video decoder to init DXVA2 decoding on the appropriate screen,
instead of having to re-init after starting the graph.

It also ensures the video decoding features of the adapter the window is currently on
are exposed, and not those of the default screen.
