### PR TITLE
[RFC] Remove P010/P016 block from IPinHook

### DIFF
--- a/src/filters/renderer/VideoRenderers/IPinHook.h
+++ b/src/filters/renderer/VideoRenderers/IPinHook.h
@@ -76,9 +76,6 @@ extern bool HookNewSegmentAndReceive(IPinC* pPinC, IMemInputPinC* pMemInputPin);
 extern void UnhookNewSegmentAndReceive();
 extern REFERENCE_TIME g_tSegmentStart, g_tSampleStart, g_rtTimePerFrame;
 
-extern void HookWorkAroundVideoDriversBug(IBaseFilter* pBF);
-extern void UnhookWorkAroundVideoDriversBug();
-
 //
 
 interface IAMVideoAcceleratorC;

--- a/src/mpc-hc/FGFilter.cpp
+++ b/src/mpc-hc/FGFilter.cpp
@@ -428,16 +428,12 @@ HRESULT CFGFilterFile::Create(IBaseFilter** ppBF, CInterfaceList<IUnknown, &IID_
 CFGFilterVideoRenderer::CFGFilterVideoRenderer(HWND hWnd, const CLSID& clsid, CStringW name, UINT64 merit)
     : CFGFilter(clsid, name, merit)
     , m_hWnd(hWnd)
-    , m_bHasVideoDriverWorkAround(false)
 {
     AddType(MEDIATYPE_Video, MEDIASUBTYPE_NULL);
 }
 
 CFGFilterVideoRenderer::~CFGFilterVideoRenderer()
 {
-    if (m_bHasVideoDriverWorkAround) {
-        UnhookWorkAroundVideoDriversBug();
-    }
 }
 
 HRESULT CFGFilterVideoRenderer::Create(IBaseFilter** ppBF, CInterfaceList<IUnknown, &IID_IUnknown>& pUnks)
@@ -504,11 +500,6 @@ HRESULT CFGFilterVideoRenderer::Create(IBaseFilter** ppBF, CInterfaceList<IUnkno
     }
 
     CheckPointer(*ppBF, E_FAIL);
-
-    if (m_clsid != CLSID_madVRAllocatorPresenter) {
-        HookWorkAroundVideoDriversBug(*ppBF);
-        m_bHasVideoDriverWorkAround = true;
-    }
 
     return hr;
 }

--- a/src/mpc-hc/FGFilter.h
+++ b/src/mpc-hc/FGFilter.h
@@ -124,7 +124,6 @@ class CFGFilterVideoRenderer : public CFGFilter
 {
 protected:
     HWND m_hWnd;
-    bool m_bHasVideoDriverWorkAround;
 
 public:
     CFGFilterVideoRenderer(HWND hWnd, const CLSID& clsid, CStringW name = L"", UINT64 merit = MERIT64_DO_USE);


### PR DESCRIPTION
P010 works in DXVA2-Native mode with EVR on some systems,
permanently blocking it would cripple that functionality.

Instead, LAV will block P010 memory buffers when connecting to EVR.

As an alternative, EVR could check if it was switched into DXVA2-Native mode before denying connection entirely.

Discuss!
