### PR TITLE
Changed the Subtitles library timestamp to REFERENCE_TIME.

### DIFF
--- a/src/Subtitles/STS.cpp
+++ b/src/Subtitles/STS.cpp
@@ -30,7 +30,6 @@
 
 #include "../DSUtil/PathUtils.h"
 
-
 static struct htmlcolor {
     TCHAR* name;
     DWORD  color;
@@ -519,8 +518,8 @@ static bool OpenSubRipper(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet
 
                 ret.Add(SubRipper2SSA(str, CharSet),
                         file->IsUnicode(),
-                        (((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1,
-                        (((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2);
+                        MS2RT((((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1),
+                        MS2RT((((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2));
             } else {
                 return false;
             }
@@ -555,8 +554,8 @@ static bool OpenOldSubRipper(CTextFile* file, CSimpleTextSubtitle& ret, int Char
             ret.Add(
                 buff.Mid(buff.Find('}', buff.Find('}') + 1) + 1),
                 file->IsUnicode(),
-                (((hh1 * 60 + mm1) * 60) + ss1) * 1000,
-                (((hh2 * 60 + mm2) * 60) + ss2) * 1000);
+                MS2RT((((hh1 * 60 + mm1) * 60) + ss1) * 1000),
+                MS2RT((((hh2 * 60 + mm2) * 60) + ss2) * 1000));
         } else if (c != EOF) { // might be another format
             return false;
         }
@@ -665,8 +664,8 @@ static bool OpenSubViewer(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet
 
             ret.Add(str,
                     file->IsUnicode(),
-                    (((hh1 * 60 + mm1) * 60) + ss1) * 1000 + hs1 * 10,
-                    (((hh2 * 60 + mm2) * 60) + ss2) * 1000 + hs2 * 10);
+                    MS2RT((((hh1 * 60 + mm1) * 60) + ss1) * 1000 + hs1 * 10),
+                    MS2RT((((hh2 * 60 + mm2) * 60) + ss2) * 1000 + hs2 * 10));
         } else if (c != EOF) { // might be another format
             return false;
         }
@@ -942,14 +941,14 @@ static bool OpenMicroDVD(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
         if (c == 2) {
             if (fCheck2 && ret.GetCount()) {
                 STSEntry& stse = ret[ret.GetCount() - 1];
-                stse.end = std::min(stse.end, start);
+                stse.end = std::min(stse.end, MS2RT(start));
                 fCheck2 = false;
             }
 
             ret.Add(
                 MicroDVD2SSA(buff.Mid(buff.Find('}', buff.Find('}') + 1) + 1), file->IsUnicode(), CharSet),
                 file->IsUnicode(),
-                start, end,
+                MS2RT(start), MS2RT(end),
                 style);
 
             if (fCheck) {
@@ -1123,7 +1122,7 @@ static bool OpenSami(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
                 ret.Add(
                     SMI2SSA(caption, CharSet),
                     file->IsUnicode(),
-                    start_time, time);
+                    MS2RT(start_time), MS2RT(time));
 
                 start_time = time;
                 caption.Empty();
@@ -1140,7 +1139,7 @@ static bool OpenSami(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
     ret.Add(
         SMI2SSA(caption, CharSet),
         file->IsUnicode(),
-        start_time, MAXLONG);
+        MS2RT(start_time), LONGLONG_MAX);
 
     return true;
 }
@@ -1168,8 +1167,8 @@ static bool OpenVPlayer(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
             CStringW str = buff.Mid(buff.Find(':', buff.Find(':', buff.Find(':') + 1) + 1) + 1);
             ret.Add(str,
                     file->IsUnicode(),
-                    (((hh * 60 + mm) * 60) + ss) * 1000,
-                    (((hh * 60 + mm) * 60) + ss) * 1000 + 1000 + 50 * str.GetLength());
+                    MS2RT((((hh * 60 + mm) * 60) + ss) * 1000),
+                    MS2RT((((hh * 60 + mm) * 60) + ss) * 1000 + 1000 + 50 * str.GetLength()));
         } else if (c != EOF) { // might be another format
             return false;
         }
@@ -1429,8 +1428,8 @@ static bool OpenSubStationAlpha(CTextFile* file, CSimpleTextSubtitle& ret, int C
 
                 ret.Add(pszBuff,
                         file->IsUnicode(),
-                        (((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1_div10 * 10,
-                        (((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2_div10 * 10,
+                        MS2RT((((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1_div10 * 10),
+                        MS2RT((((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2_div10 * 10),
                         style, actor, effect,
                         marginRect,
                         layer);
@@ -1715,8 +1714,8 @@ static bool OpenXombieSub(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet
 
                 ret.Add(pszBuff,
                         file->IsUnicode(),
-                        (((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1,
-                        (((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2,
+                        MS2RT((((hh1 * 60 + mm1) * 60) + ss1) * 1000 + ms1),
+                        MS2RT((((hh2 * 60 + mm2) * 60) + ss2) * 1000 + ms2),
                         style, actor, _T(""),
                         marginRect,
                         layer);
@@ -1775,7 +1774,8 @@ static bool OpenMPL2(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
             ret.Add(
                 MPL22SSA(buff.Mid(buff.Find(']', buff.Find(']') + 1) + 1), file->IsUnicode(), CharSet),
                 file->IsUnicode(),
-                start * 100, end * 100);
+                MS2RT(start * 100),
+                MS2RT(end * 100));
         } else if (c != EOF) { // might be another format
             return false;
         }
@@ -1866,7 +1866,7 @@ void CSimpleTextSubtitle::Copy(CSimpleTextSubtitle& sts)
     }
 }
 
-void CSimpleTextSubtitle::Append(CSimpleTextSubtitle& sts, int timeoff)
+void CSimpleTextSubtitle::Append(CSimpleTextSubtitle& sts, REFERENCE_TIME timeoff)
 {
     if (timeoff < 0) {
         timeoff = !IsEmpty() ? GetAt(GetCount() - 1).end : 0;
@@ -1943,7 +1943,7 @@ static bool SegmentCompStart(const STSSegment& segment, int start)
     return (segment.start < start);
 }
 
-void CSimpleTextSubtitle::Add(CStringW str, bool fUnicode, int start, int end, CString style, CString actor, CString effect, const CRect& marginRect, int layer, int readorder)
+void CSimpleTextSubtitle::Add(CStringW str, bool fUnicode, REFERENCE_TIME start, REFERENCE_TIME end, CString style, CString actor, CString effect, const CRect& marginRect, int layer, int readorder)
 {
     FastTrim(str);
     if (str.IsEmpty() || start > end) {
@@ -2008,7 +2008,7 @@ void CSimpleTextSubtitle::Add(CStringW str, bool fUnicode, int start, int end, C
             i++;
         }
 
-        int lastEnd = INT_MAX;
+        REFERENCE_TIME lastEnd = _I64_MAX;
         for (; i < m_segments.GetCount() && m_segments[i].start < end; i++) {
             STSSegment& s = m_segments[i];
 
@@ -2186,8 +2186,8 @@ void CSimpleTextSubtitle::ConvertToTimeBased(double fps)
 
     for (size_t i = 0, j = GetCount(); i < j; i++) {
         STSEntry& stse = (*this)[i];
-        stse.start = (int)(stse.start * 1000.0 / fps + 0.5);
-        stse.end   = (int)(stse.end * 1000.0 / fps + 0.5);
+        stse.start = (REFERENCE_TIME)(stse.start * UNITS_FLOAT / fps + 0.5);
+        stse.end   = (REFERENCE_TIME)(stse.end * UNITS_FLOAT / fps + 0.5);
     }
 
     m_mode = TIME;
@@ -2203,8 +2203,8 @@ void CSimpleTextSubtitle::ConvertToFrameBased(double fps)
 
     for (size_t i = 0, j = GetCount(); i < j; i++) {
         STSEntry& stse = (*this)[i];
-        stse.start = (int)(stse.start * fps / 1000 + 0.5);
-        stse.end   = (int)(stse.end * fps / 1000 + 0.5);
+        stse.start = (REFERENCE_TIME)(stse.start * fps / UNITS + 0.5);
+        stse.end   = (REFERENCE_TIME)(stse.end * fps / UNITS + 0.5);
     }
 
     m_mode = FRAME;
@@ -2212,7 +2212,7 @@ void CSimpleTextSubtitle::ConvertToFrameBased(double fps)
     CreateSegments();
 }
 
-int CSimpleTextSubtitle::SearchSub(int t, double fps)
+int CSimpleTextSubtitle::SearchSub(REFERENCE_TIME t, double fps)
 {
     int i = 0, j = (int)GetCount() - 1, ret = -1;
 
@@ -2223,7 +2223,7 @@ int CSimpleTextSubtitle::SearchSub(int t, double fps)
     while (i < j) {
         int mid = (i + j) >> 1;
 
-        int midt = TranslateStart(mid, fps);
+        REFERENCE_TIME midt = TranslateStart(mid, fps);
 
         if (t == midt) {
             while (mid > 0 && t == TranslateStart(mid - 1, fps)) {
@@ -2249,7 +2249,7 @@ int CSimpleTextSubtitle::SearchSub(int t, double fps)
     return ret;
 }
 
-const STSSegment* CSimpleTextSubtitle::SearchSubs(int t, double fps, /*[out]*/ int* iSegment, int* nSegments)
+const STSSegment* CSimpleTextSubtitle::SearchSubs(REFERENCE_TIME t, double fps, /*[out]*/ int* iSegment, int* nSegments)
 {
     int i = 0, j = (int)m_segments.GetCount() - 1, ret = -1;
 
@@ -2284,7 +2284,7 @@ const STSSegment* CSimpleTextSubtitle::SearchSubs(int t, double fps, /*[out]*/ i
     while (i < j) {
         int mid = (i + j) >> 1;
 
-        int midt = TranslateSegmentStart(mid, fps);
+        REFERENCE_TIME midt = TranslateSegmentStart(mid, fps);
 
         if (t == midt) {
             ret = mid;
@@ -2319,35 +2319,35 @@ const STSSegment* CSimpleTextSubtitle::SearchSubs(int t, double fps, /*[out]*/ i
     return nullptr;
 }
 
-int CSimpleTextSubtitle::TranslateStart(int i, double fps)
+REFERENCE_TIME CSimpleTextSubtitle::TranslateStart(int i, double fps)
 {
     return (i < 0 || GetCount() <= (size_t)i ? -1 :
             m_mode == TIME ? GetAt(i).start :
-            m_mode == FRAME ? (int)(GetAt(i).start * 1000 / fps) :
+            m_mode == FRAME ? (REFERENCE_TIME)(GetAt(i).start * UNITS_FLOAT / fps) :
             0);
 }
 
-int CSimpleTextSubtitle::TranslateEnd(int i, double fps)
+REFERENCE_TIME CSimpleTextSubtitle::TranslateEnd(int i, double fps)
 {
     return (i < 0 || GetCount() <= (size_t)i ? -1 :
             m_mode == TIME ? GetAt(i).end :
-            m_mode == FRAME ? (int)(GetAt(i).end * 1000 / fps) :
+            m_mode == FRAME ? (REFERENCE_TIME)(GetAt(i).end * UNITS_FLOAT / fps) :
             0);
 }
 
-int CSimpleTextSubtitle::TranslateSegmentStart(int i, double fps)
+REFERENCE_TIME CSimpleTextSubtitle::TranslateSegmentStart(int i, double fps)
 {
     return (i < 0 || m_segments.GetCount() <= (size_t)i ? -1 :
             m_mode == TIME ? m_segments[i].start :
-            m_mode == FRAME ? (int)(m_segments[i].start * 1000 / fps) :
+            m_mode == FRAME ? (REFERENCE_TIME)(m_segments[i].start * UNITS_FLOAT / fps) :
             0);
 }
 
-int CSimpleTextSubtitle::TranslateSegmentEnd(int i, double fps)
+REFERENCE_TIME CSimpleTextSubtitle::TranslateSegmentEnd(int i, double fps)
 {
     return (i < 0 || m_segments.GetCount() <= (size_t)i ? -1 :
             m_mode == TIME ? m_segments[i].end :
-            m_mode == FRAME ? (int)(m_segments[i].end * 1000 / fps) :
+            m_mode == FRAME ? (REFERENCE_TIME)(m_segments[i].end * UNITS_FLOAT / fps) :
             0);
 }
 
@@ -2516,9 +2516,15 @@ void CSimpleTextSubtitle::SetStr(int i, CStringW str, bool fUnicode)
     }
 }
 
+// Comparator which helps comparing REFERENCE_TIME arguments safely.
+static inline int RTComp(REFERENCE_TIME t)
+{
+    return ((t < 0) ? -1 : ((t > 0) ? 1 : 0));
+}
+
 static int comp1(const void* a, const void* b)
 {
-    int ret = ((STSEntry*)a)->start - ((STSEntry*)b)->start;
+    int ret = RTComp(((STSEntry*)a)->start - ((STSEntry*)b)->start);
     if (ret == 0) {
         ret = ((STSEntry*)a)->layer - ((STSEntry*)b)->layer;
     }
@@ -2540,10 +2546,10 @@ void CSimpleTextSubtitle::Sort(bool fRestoreReadorder)
 }
 
 struct Breakpoint {
-    int t;
+    REFERENCE_TIME t;
     bool isStart;
 
-    Breakpoint(int t, bool isStart) : t(t), isStart(isStart) {};
+    Breakpoint(REFERENCE_TIME t, bool isStart) : t(t), isStart(isStart) {};
 };
 
 static int BreakpointComp(const void* e1, const void* e2)
@@ -2551,7 +2557,7 @@ static int BreakpointComp(const void* e1, const void* e2)
     const Breakpoint* bp1 = (const Breakpoint*)e1;
     const Breakpoint* bp2 = (const Breakpoint*)e2;
 
-    return (bp1->t - bp2->t);
+    return RTComp(bp1->t - bp2->t);
 }
 
 void CSimpleTextSubtitle::CreateSegments()
@@ -2713,7 +2719,7 @@ bool CSimpleTextSubtitle::Open(BYTE* data, int len, int CharSet, CString name)
 }
 
 bool CSimpleTextSubtitle::SaveAs(CString fn, Subtitle::SubType type,
-                                 double fps /*= -1*/, int delay /*= 0*/,
+                                 double fps /*= -1*/, LONGLONG delay /*= 0*/,
                                  CTextFile::enc e /*= CTextFile::DEFAULT_ENCODING*/, bool bCreateExternalStyleFile /*= true*/)
 {
     LPCTSTR ext = Subtitle::GetSubtitleFileExt(type);
@@ -2846,13 +2852,13 @@ bool CSimpleTextSubtitle::SaveAs(CString fn, Subtitle::SubType type,
     for (int i = 0, j = (int)GetCount(), k = 0; i < j; i++) {
         STSEntry& stse = GetAt(i);
 
-        int t1 = TranslateStart(i, fps) + delay;
+        int t1 = (int)(RT2MS(TranslateStart(i, fps)) + delay);
         if (t1 < 0) {
             k++;
             continue;
         }
 
-        int t2 = TranslateEnd(i, fps) + delay;
+        int t2 = (int)(RT2MS(TranslateEnd(i, fps)) + delay);
 
         int hh1 = (t1 / 60 / 60 / 1000);
         int mm1 = (t1 / 60 / 1000) % 60;
@@ -3163,8 +3169,8 @@ static bool OpenRealText(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet)
         ret.Add(
             SubRipper2SSA(i->second.c_str(), CharSet),
             file->IsUnicode(),
-            i->first.first,
-            i->first.second);
+            MS2RT(i->first.first),
+            MS2RT(i->first.second));
     }
 
     return !ret.IsEmpty();

--- a/src/Subtitles/STS.h
+++ b/src/Subtitles/STS.h
@@ -93,20 +93,20 @@ struct STSEntry {
     CString style, actor, effect;
     CRect marginRect;
     int layer;
-    int start, end;
+    REFERENCE_TIME start, end;
     int readorder;
 };
 
 class STSSegment
 {
 public:
-    int start, end;
+    REFERENCE_TIME start, end;
     CAtlArray<int> subs;
 
     STSSegment()
         : start(0)
         , end(0) {}
-    STSSegment(int s, int e) {
+    STSSegment(REFERENCE_TIME s, REFERENCE_TIME e) {
         start = s;
         end = e;
     }
@@ -170,14 +170,14 @@ public:
     void Sort(bool fRestoreReadorder = false);
     void CreateSegments();
 
-    void Append(CSimpleTextSubtitle& sts, int timeoff = -1);
+    void Append(CSimpleTextSubtitle& sts, REFERENCE_TIME timeoff = -1);
 
     bool Open(CString fn, int CharSet, CString name = _T(""), CString videoName = _T(""));
     bool Open(CTextFile* f, int CharSet, CString name);
     bool Open(BYTE* data, int len, int CharSet, CString name);
-    bool SaveAs(CString fn, Subtitle::SubType type, double fps = -1, int delay = 0, CTextFile::enc e = CTextFile::DEFAULT_ENCODING, bool bCreateExternalStyleFile = true);
+    bool SaveAs(CString fn, Subtitle::SubType type, double fps = -1, LONGLONG delay = 0, CTextFile::enc e = CTextFile::DEFAULT_ENCODING, bool bCreateExternalStyleFile = true);
 
-    void Add(CStringW str, bool fUnicode, int start, int end, CString style = _T("Default"), CString actor = _T(""), CString effect = _T(""), const CRect& marginRect = CRect(0, 0, 0, 0), int layer = 0, int readorder = -1);
+    void Add(CStringW str, bool fUnicode, REFERENCE_TIME start, REFERENCE_TIME end, CString style = _T("Default"), CString actor = _T(""), CString effect = _T(""), const CRect& marginRect = CRect(0, 0, 0, 0), int layer = 0, int readorder = -1);
     STSStyle* CreateDefaultStyle(int CharSet);
     void ChangeUnknownStylesToDefault();
     void AddStyle(CString name, STSStyle* style); // style will be stored and freed in Empty() later
@@ -189,13 +189,13 @@ public:
     void ConvertToTimeBased(double fps);
     void ConvertToFrameBased(double fps);
 
-    int TranslateStart(int i, double fps);
-    int TranslateEnd(int i, double fps);
-    int SearchSub(int t, double fps);
+    REFERENCE_TIME TranslateStart(int i, double fps);
+    REFERENCE_TIME TranslateEnd(int i, double fps);
+    int SearchSub(REFERENCE_TIME t, double fps);
 
-    int TranslateSegmentStart(int i, double fps);
-    int TranslateSegmentEnd(int i, double fps);
-    const STSSegment* SearchSubs(int t, double fps, /*[out]*/ int* iSegment = nullptr, int* nSegments = nullptr);
+    REFERENCE_TIME TranslateSegmentStart(int i, double fps);
+    REFERENCE_TIME TranslateSegmentEnd(int i, double fps);
+    const STSSegment* SearchSubs(REFERENCE_TIME t, double fps, /*[out]*/ int* iSegment = nullptr, int* nSegments = nullptr);
     const STSSegment* GetSegment(int iSegment) {
         return iSegment >= 0 && iSegment < (int)m_segments.GetCount() ? &m_segments[iSegment] : nullptr;
     }

--- a/src/Subtitles/SubtitleHelpers.h
+++ b/src/Subtitles/SubtitleHelpers.h
@@ -24,6 +24,10 @@
 #include <afx.h>
 #include <atlcoll.h>
 
+#define MS2RT(t)        (10000i64 * (t))
+#define RT2MS(t)        ((t) / 10000)
+#define UNITS_FLOAT     (10000000.0)
+
 namespace Subtitle
 {
     enum SubType {

--- a/src/Subtitles/SubtitleInputPin.cpp
+++ b/src/Subtitles/SubtitleInputPin.cpp
@@ -379,12 +379,12 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
                 if (tag == __GAB1_LANGUAGE__) {
                     pRTS->m_name = CString(ptr);
                 } else if (tag == __GAB1_ENTRY__) {
-                    pRTS->Add(AToW(&ptr[8]), false, *(int*)ptr, *(int*)(ptr + 4));
+                    pRTS->Add(AToW(&ptr[8]), false, MS2RT(*(int*)ptr), MS2RT(*(int*)(ptr + 4)));
                     bInvalidate = true;
                 } else if (tag == __GAB1_LANGUAGE_UNICODE__) {
                     pRTS->m_name = (WCHAR*)ptr;
                 } else if (tag == __GAB1_ENTRY_UNICODE__) {
-                    pRTS->Add((WCHAR*)(ptr + 8), true, *(int*)ptr, *(int*)(ptr + 4));
+                    pRTS->Add((WCHAR*)(ptr + 8), true, MS2RT(*(int*)ptr), MS2RT(*(int*)(ptr + 4)));
                     bInvalidate = true;
                 }
 
@@ -416,7 +416,7 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
             str.Trim();
 
             if (!str.IsEmpty()) {
-                pRTS->Add(AToW(str), false, (int)(pSample->rtStart / 10000), (int)(pSample->rtStop / 10000));
+                pRTS->Add(AToW(str), false, pSample->rtStart, pSample->rtStop);
                 bInvalidate = true;
             }
         }
@@ -426,7 +426,7 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
 
             CStringW str = UTF8To16(CStringA((LPCSTR)pSample->data.data(), (int)pSample->data.size())).Trim();
             if (!str.IsEmpty()) {
-                pRTS->Add(str, true, (int)(pSample->rtStart / 10000), (int)(pSample->rtStop / 10000));
+                pRTS->Add(str, true, pSample->rtStart, pSample->rtStop);
                 bInvalidate = true;
             }
         } else if (m_mt.subtype == MEDIASUBTYPE_SSA || m_mt.subtype == MEDIASUBTYPE_ASS || m_mt.subtype == MEDIASUBTYPE_ASS2) {
@@ -456,7 +456,7 @@ REFERENCE_TIME CSubtitleInputPin::DecodeSample(const std::unique_ptr<SubtitleSam
                 }
 
                 if (!stse.str.IsEmpty()) {
-                    pRTS->Add(stse.str, true, (int)(pSample->rtStart / 10000), (int)(pSample->rtStop / 10000),
+                    pRTS->Add(stse.str, true, pSample->rtStart, pSample->rtStop,
                               stse.style, stse.actor, stse.effect, stse.marginRect, stse.layer, stse.readorder);
                     bInvalidate = true;
                 }

--- a/src/filters/transform/VSFilter/Copy.cpp
+++ b/src/filters/transform/VSFilter/Copy.cpp
@@ -184,10 +184,10 @@ void CDirectVobSubFilter::PrintMessages(BYTE* pOut)
                bihOut.biWidth, bihOut.biHeight,
                Subtype2String(m_pOutput->CurrentMediaType().subtype));
 
-    msg.AppendFormat(_T("real fps: %.3f, current fps: %.3f\nmedia time: %d, subtitle time: %I64d [ms]\nframe number: %d (calculated)\nrate: %.4lf\n"),
+    msg.AppendFormat(_T("real fps: %.3f, current fps: %.3f\nmedia time: %I64d, subtitle time: %I64d [ms]\nframe number: %I64d (calculated)\nrate: %.4lf\n"),
                      m_fps, m_fMediaFPSEnabled ? m_MediaFPS : fabs(m_fps),
-                     m_tPrev.Millisecs(), CalcCurrentTime() / 10000,
-                     (int)(m_tPrev.m_time * m_fps / 10000000),
+                     RT2MS(m_tPrev.GetUnits()), RT2MS(CalcCurrentTime()),
+                     (LONGLONG)(m_tPrev.m_time * m_fps / UNITS),
                      m_pInput->CurrentRate());
 
     CAutoLock cAutoLock(&m_csQueueLock);
@@ -196,11 +196,11 @@ void CDirectVobSubFilter::PrintMessages(BYTE* pOut)
         int nSubPics = -1;
         REFERENCE_TIME rtNow = -1, rtStart = -1, rtStop = -1;
         m_pSubPicQueue->GetStats(nSubPics, rtNow, rtStart, rtStop);
-        msg.AppendFormat(_T("queue stats: %I64d - %I64d [ms]\n"), rtStart / 10000, rtStop / 10000);
+        msg.AppendFormat(_T("queue stats: %I64d - %I64d [ms]\n"), RT2MS(rtStart), RT2MS(rtStop));
 
         for (int i = 0; i < nSubPics; i++) {
             m_pSubPicQueue->GetStats(i, rtStart, rtStop);
-            msg.AppendFormat(_T("%d: %I64d - %I64d [ms]\n"), i, rtStart / 10000, rtStop / 10000);
+            msg.AppendFormat(_T("%d: %I64d - %I64d [ms]\n"), i, RT2MS(rtStart), RT2MS(rtStop));
         }
     }
 

--- a/src/filters/transform/VSFilter/DirectVobSub.cpp
+++ b/src/filters/transform/VSFilter/DirectVobSub.cpp
@@ -55,6 +55,10 @@ CDirectVobSub::CDirectVobSub()
     m_fMediaFPSEnabled = !!theApp.GetProfileInt(ResStr(IDS_R_TIMING), ResStr(IDS_RTM_MEDIAFPSENABLED), FALSE);
     m_ePARCompensationType = static_cast<CSimpleTextSubtitle::EPARCompensationType>(theApp.GetProfileInt(ResStr(IDS_R_TEXT), ResStr(IDS_RT_AUTOPARCOMPENSATION), 0));
 
+    int gcd = GCD(m_SubtitleSpeedMul, m_SubtitleSpeedDiv);
+    m_SubtitleSpeedNormalizedMul = m_SubtitleSpeedMul / gcd;
+    m_SubtitleSpeedNormalizedDiv = m_SubtitleSpeedDiv / gcd;
+
     BYTE* pData = nullptr;
     UINT nSize;
     if (theApp.GetProfileBinary(ResStr(IDS_R_TIMING), ResStr(IDS_RTM_MEDIAFPS), &pData, &nSize) && pData) {
@@ -458,6 +462,10 @@ STDMETHODIMP CDirectVobSub::put_SubtitleTiming(int delay, int speedmul, int spee
     if (speeddiv > 0) {
         m_SubtitleSpeedDiv = speeddiv;
     }
+
+    int gcd = GCD(m_SubtitleSpeedMul, m_SubtitleSpeedDiv);
+    m_SubtitleSpeedNormalizedMul = m_SubtitleSpeedMul / gcd;
+    m_SubtitleSpeedNormalizedDiv = m_SubtitleSpeedDiv / gcd;
 
     return S_OK;
 }

--- a/src/filters/transform/VSFilter/DirectVobSub.h
+++ b/src/filters/transform/VSFilter/DirectVobSub.h
@@ -49,6 +49,9 @@ protected:
     bool m_fOSD;
     int m_nReloaderDisableCount;
     int m_SubtitleDelay, m_SubtitleSpeedMul, m_SubtitleSpeedDiv;
+    // User could specify any values for m_SubtitleSpeedMul and m_SubtitleSpeedDiv.
+    // We want to normalize the user input to minimize the chance of overflow later when we do calculations.
+    int m_SubtitleSpeedNormalizedMul, m_SubtitleSpeedNormalizedDiv;
     bool m_fMediaFPSEnabled;
     double m_MediaFPS;
     bool m_fSaveFullPath;

--- a/src/filters/transform/VSFilter/DirectVobSubFilter.cpp
+++ b/src/filters/transform/VSFilter/DirectVobSubFilter.cpp
@@ -518,7 +518,7 @@ HRESULT CDirectVobSubFilter::NewSegment(REFERENCE_TIME tStart, REFERENCE_TIME tS
 REFERENCE_TIME CDirectVobSubFilter::CalcCurrentTime()
 {
     REFERENCE_TIME rt = m_pSubClock ? m_pSubClock->GetTime() : m_tPrev;
-    return (rt - 10000i64 * m_SubtitleDelay) * m_SubtitleSpeedMul / m_SubtitleSpeedDiv; // no, it won't overflow if we use normal parameters (__int64 is enough for about 2000 hours if we multiply it by the max: 65536 as m_SubtitleSpeedMul)
+    return (rt - 10000i64 * m_SubtitleDelay) * m_SubtitleSpeedNormalizedMul / m_SubtitleSpeedNormalizedDiv; // no, it won't overflow if we use normal parameters (__int64 is enough for about 2000 hours if we multiply it by the max: 65536 as m_SubtitleSpeedMul)
 }
 
 void CDirectVobSubFilter::InitSubPicQueue()

--- a/src/mpc-hc/PlayerSubresyncBar.h
+++ b/src/mpc-hc/PlayerSubresyncBar.h
@@ -88,10 +88,10 @@ private:
     };
     MODE m_mode;
 
-    std::multimap<int, size_t> m_newStartsIndex;
+    std::multimap<REFERENCE_TIME, size_t> m_newStartsIndex;
     struct SubTime {
-        int orgStart, newStart, orgEnd, newEnd;
-        std::multimap<int, size_t>::iterator itIndex;
+        REFERENCE_TIME orgStart, newStart, orgEnd, newEnd;
+        std::multimap<REFERENCE_TIME, size_t>::iterator itIndex;
     };
     std::vector<SubTime> m_subtimes;
 
@@ -99,14 +99,11 @@ private:
     CAtlArray<CVobSubFile::SubPos> m_vobSub;
 
     struct DisplayData {
-        int tStart, tPrevStart, tEnd, tPrevEnd;
+        REFERENCE_TIME tStart, tPrevStart, tEnd, tPrevEnd;
         int flags;
     };
     std::vector<DisplayData> m_displayData;
     CString m_displayBuffer;
-
-    int GetStartTime(int iItem);
-    int GetEndTime(int iItem);
 
     void UpdatePreview();
 
@@ -118,14 +115,14 @@ private:
         TSEP  = 0x80000000
     };
 
-    void SetSTS0(int& start, int end, int ti0);
-    void SetSTS1(int& start, int end, int ti0, double m, int i0);
+    void SetSTS0(int& start, int end, REFERENCE_TIME ti0);
+    void SetSTS1(int& start, int end, REFERENCE_TIME ti0, double m, int i0);
 
     void GetCheck(int iItem, bool& fStartMod, bool& fEndMod, bool& fStartAdj, bool& fEndAdj) const;
     void SetCheck(int iItem, bool fStart, bool fEnd);
 
-    bool ModStart(int iItem, int t, bool fReset = false);
-    bool ModEnd(int iItem, int t, bool fReset = false);
+    bool ModStart(int iItem, REFERENCE_TIME t, bool fReset = false);
+    bool ModEnd(int iItem, REFERENCE_TIME t, bool fReset = false);
 
     void OnGetDisplayInfoTextSub(LV_ITEM* pItem);
     void OnGetDisplayInfoVobSub(LV_ITEM* pItem);


### PR DESCRIPTION
REFERENCE_TIME type is used instead of  int for the VSFilter timestamps.

This replaces the pull request # 155.

I did not change the engine to minimize the risks for this particular commit. This could be done as a separate patch, once we have this one in.