### PR TITLE
Divide by 0 workaround (SeparableFilterX_SSE2)

### DIFF
--- a/src/Subtitles/SeparableFilter.h
+++ b/src/Subtitles/SeparableFilter.h
@@ -361,6 +361,7 @@ struct GaussianKernel {
         for (int x = width / 2 - 1; x >= 0; x--) {
             short val = (short)(NormalDist(sigma, width / 2 - x) * 255 + 0.5);
             divisor += val * 2;
+			if (divisor == 0) divisor = 1;
             kernel[x] = val;
             kernel[width - x - 1] = val;
         }


### PR DESCRIPTION
The divisor can become 0. When this happens it causes
SeparableFilterX_SSE2 to divide by zero resulting in a crash.
( https://drdump.com/DumpGroup.aspx?DumpGroupID=400433 )

This workaround ensures SeparableFilterX_SSE2 does not receive a 0
divisor thus preventing a crash.