### PR TITLE
Add shader settings support in external .json

### DIFF
--- a/include/mpc-hc_config.h
+++ b/include/mpc-hc_config.h
@@ -1,6 +1,6 @@
 #ifndef ISPP_INVOKED
 /*
- * (C) 2013-2015 see Authors.txt
+ * (C) 2013-2016 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -46,6 +46,7 @@
 
 #define SHADERS_DIR _T("Shaders")
 #define SHADERS_EXT _T(".hlsl")
+#define SHADERS_CFG _T(".json")
 
 // If this is enabled, the registered LAV Filters can be loaded as internal filters
 #define ENABLE_LOAD_EXTERNAL_LAVF_AS_INTERNAL 0

--- a/src/SubPic/ISubPic.h
+++ b/src/SubPic/ISubPic.h
@@ -227,3 +227,13 @@ public IPersist {
     // TODO: get rid of IPersist to identify type and use only
     // interface functions to modify the settings of the substream
 };
+
+//
+// ISubPicShaderPresenter
+//
+interface __declspec(uuid("212C1425-F407-4FF6-B0A0-8335FA46ABA8"))
+ISubPicShaderPresenter :
+public IUnknown {
+    STDMETHOD(SetPixelShaderTexture)(int registerId, const CString& path, int filter, int wrap) PURE;
+    STDMETHOD(SetPixelShaderParameter)(int registerId, const float values[4]) PURE;
+};

--- a/src/SubPic/SubPicAllocatorPresenterImpl.cpp
+++ b/src/SubPic/SubPicAllocatorPresenterImpl.cpp
@@ -71,6 +71,7 @@ STDMETHODIMP CSubPicAllocatorPresenterImpl::NonDelegatingQueryInterface(REFIID r
         QI(ISubRenderOptions)
         QI(ISubRenderConsumer)
         QI(ISubRenderConsumer2)
+        QI(ISubPicShaderPresenter)
         __super::NonDelegatingQueryInterface(riid, ppv);
 }
 

--- a/src/SubPic/SubPicAllocatorPresenterImpl.h
+++ b/src/SubPic/SubPicAllocatorPresenterImpl.h
@@ -33,6 +33,7 @@ class CSubPicAllocatorPresenterImpl
     , public CCritSec
     , public ISubPicAllocatorPresenter2
     , public ISubRenderConsumer2
+    , public ISubPicShaderPresenter
 {
 private:
     CCritSec m_csSubPicProvider;
@@ -153,4 +154,14 @@ public:
     // ISubRenderConsumer2
 
     STDMETHODIMP Clear(REFERENCE_TIME clearNewerThan = 0);
+
+    // ISubPicShaderPresenter
+
+    STDMETHODIMP SetPixelShaderTexture(int registerId, const CString& path, int filter, int wrap) {
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP SetPixelShaderParameter(int registerId, const float values[4]) {
+        return E_NOTIMPL;
+    }
 };

--- a/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
+++ b/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.cpp
@@ -2287,3 +2287,17 @@ STDMETHODIMP CDX9AllocatorPresenter::GetD3DFullscreen(bool* pfEnabled)
     *pfEnabled = m_bIsFullscreen;
     return S_OK;
 }
+
+STDMETHODIMP CDX9AllocatorPresenter::SetPixelShaderTexture(int registerId, const CString& path, int filter, int wrap)
+{
+    CAutoLock cRenderLock(&m_RenderLock);
+
+    return SetCustomPixelShaderTexture(registerId, path, filter, wrap);
+}
+
+STDMETHODIMP CDX9AllocatorPresenter::SetPixelShaderParameter(int registerId, const float values[4])
+{
+    CAutoLock cRenderLock(&m_RenderLock);
+
+    return SetCustomPixelShaderParameter(registerId, values);
+}

--- a/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.h
+++ b/src/filters/renderer/VideoRenderers/DX9AllocatorPresenter.h
@@ -1,6 +1,6 @@
 /*
  * (C) 2003-2006 Gabest
- * (C) 2006-2015 see Authors.txt
+ * (C) 2006-2016 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -308,5 +308,9 @@ namespace DSObjects
         // ID3DFullscreenControl
         STDMETHODIMP SetD3DFullscreen(bool fEnabled);
         STDMETHODIMP GetD3DFullscreen(bool* pfEnabled);
+
+        // ISubPicShaderPresenter
+        STDMETHODIMP SetPixelShaderTexture(int registerId, const CString& path, int filter, int wrap);
+        STDMETHODIMP SetPixelShaderParameter(int registerId, const float values[4]);
     };
 }

--- a/src/filters/renderer/VideoRenderers/PixelShaderCompiler.cpp
+++ b/src/filters/renderer/VideoRenderers/PixelShaderCompiler.cpp
@@ -57,10 +57,8 @@ CPixelShaderCompiler::~CPixelShaderCompiler()
     }
 }
 
-HRESULT CPixelShaderCompiler::InternalCompile(
+HRESULT CPixelShaderCompiler::CompileShader(
     LPCSTR pSrcData,
-    SIZE_T SrcDataSize,
-    LPCSTR pSourceName,
     LPCSTR pEntrypoint,
     LPCSTR pProfile,
     DWORD Flags,
@@ -123,7 +121,7 @@ HRESULT CPixelShaderCompiler::InternalCompile(
     D3D_SHADER_MACRO macros[] = { { defProfile, defProfileVal }, { 0 } };
 
     CComPtr<ID3DBlob> pShaderBlob, pErrorBlob;
-    HRESULT hr = m_pD3DCompile(pSrcData, SrcDataSize, pSourceName, macros, nullptr, pEntrypoint,
+    HRESULT hr = m_pD3DCompile(pSrcData, strlen(pSrcData), nullptr, macros, nullptr, pEntrypoint,
                                pSelProfile, Flags, 0, &pShaderBlob, &pErrorBlob);
 
     if (pErrMsg) {
@@ -169,50 +167,4 @@ HRESULT CPixelShaderCompiler::InternalCompile(
     }
 
     return S_OK;
-}
-
-HRESULT CPixelShaderCompiler::CompileShader(
-    LPCSTR pSrcData,
-    LPCSTR pEntrypoint,
-    LPCSTR pProfile,
-    DWORD Flags,
-    IDirect3DPixelShader9** ppPixelShader,
-    CString* pDisasm,
-    CString* pErrMsg)
-{
-    return InternalCompile(pSrcData, strlen(pSrcData), nullptr, pEntrypoint,
-                           pProfile, Flags, ppPixelShader, pDisasm, pErrMsg);
-}
-
-HRESULT CPixelShaderCompiler::CompileShaderFromFile(
-    LPCTSTR pSrcFile,
-    LPCSTR pEntrypoint,
-    LPCSTR pProfile,
-    DWORD Flags,
-    IDirect3DPixelShader9** ppPixelShader,
-    CString* pDisasm,
-    CString* pErrMsg)
-{
-    HRESULT ret = E_FAIL;
-    if (FILE* fp = _tfsopen(pSrcFile, _T("rb"), _SH_SECURE)) {
-        VERIFY(fseek(fp, 0, SEEK_END) == 0);
-        long size = ftell(fp);
-        rewind(fp);
-        if (size > 0) {
-            auto data = new(std::nothrow) char[(size_t)size];
-            if (data) {
-                if (fread(data, size, 1, fp) == 1) {
-                    ret = InternalCompile(data, (size_t)size, CT2A(pSrcFile), pEntrypoint,
-                                          pProfile, Flags, ppPixelShader, pDisasm, pErrMsg);
-                } else {
-                    ASSERT(FALSE);
-                }
-                delete[] data;
-            } else {
-                ASSERT(FALSE);
-            }
-        }
-        VERIFY(fclose(fp) == 0);
-    }
-    return ret;
 }

--- a/src/filters/renderer/VideoRenderers/PixelShaderCompiler.h
+++ b/src/filters/renderer/VideoRenderers/PixelShaderCompiler.h
@@ -33,32 +33,12 @@ class CPixelShaderCompiler
 
     CComPtr<IDirect3DDevice9> m_pD3DDev;
 
-    HRESULT InternalCompile(
-        LPCSTR pSrcData,
-        SIZE_T SrcDataSize,
-        LPCSTR pSourceName,
-        LPCSTR pEntrypoint,
-        LPCSTR pProfile,
-        DWORD Flags,
-        IDirect3DPixelShader9** ppPixelShader,
-        CString* pDisasm,
-        CString* pErrMsg);
-
 public:
     CPixelShaderCompiler(IDirect3DDevice9* pD3DDev, bool fStaySilent = false);
     ~CPixelShaderCompiler();
 
     HRESULT CompileShader(
         LPCSTR pSrcData,
-        LPCSTR pEntrypoint,
-        LPCSTR pProfile,
-        DWORD Flags,
-        IDirect3DPixelShader9** ppPixelShader,
-        CString* pDisasm = nullptr,
-        CString* pErrMsg = nullptr);
-
-    HRESULT CompileShaderFromFile(
-        LPCTSTR pSrcFile,
         LPCSTR pEntrypoint,
         LPCSTR pProfile,
         DWORD Flags,

--- a/src/mpc-hc/DebugShadersDlg.cpp
+++ b/src/mpc-hc/DebugShadersDlg.cpp
@@ -1,5 +1,5 @@
 /*
- * (C) 2013-2015 see Authors.txt
+ * (C) 2013-2016 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -182,10 +182,10 @@ void CDebugShadersDlg::OnListRefresh()
     list.insert(list.cend(), s.m_ShadersExtraList.cbegin(), s.m_ShadersExtraList.cend());
     m_Shaders.ResetContent();
     for (const auto& shader : list) {
-        ASSERT(!shader.filePath.IsEmpty());
-        int idx = m_Shaders.InsertString(-1, shader.filePath);
+        ASSERT(!shader.GetFilePath().IsEmpty());
+        int idx = m_Shaders.InsertString(-1, shader.GetFilePath());
         if (idx >= 0) {
-            if (shader.filePath == path) {
+            if (shader.GetFilePath() == path) {
                 VERIFY(m_Shaders.SetCurSel(idx) != CB_ERR);
             }
         } else {
@@ -227,9 +227,10 @@ void CDebugShadersDlg::OnRecompileShader()
     }
     int sel = m_Shaders.GetCurSel();
     if (sel != CB_ERR) {
-        Shader shader;
-        m_Shaders.GetLBText(sel, shader.filePath);
-        if (PathUtils::IsFile(shader.filePath)) {
+        CString shaderPath;
+        m_Shaders.GetLBText(sel, shaderPath);
+        if (PathUtils::IsFile(shaderPath)) {
+            Shader shader(shaderPath);
             CStringA profile;
             switch (m_iVersion) {
                 case ps_2_0:
@@ -250,8 +251,8 @@ void CDebugShadersDlg::OnRecompileShader()
                     break;
             }
             CString disasm, compilerMsg;
-            if (SUCCEEDED(m_Compiler.CompileShaderFromFile(shader.filePath, "main", profile,
-                                                           D3DXSHADER_DEBUG, nullptr, &disasm, &compilerMsg))) {
+            if (SUCCEEDED(m_Compiler.CompileShader(shader.GetCode(), "main", profile,
+                                                   D3DXSHADER_DEBUG, nullptr, &disasm, &compilerMsg))) {
                 if (!compilerMsg.IsEmpty()) {
                     compilerMsg += _T("\n");
                 }

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -582,6 +582,9 @@ public:
     CString GetCaptureTitle();
 
     // shaders
+private:
+    bool SetShaderListP2(const ShaderList& shaderList, bool bScreenSpace);
+public:
     void SetShaders(bool bSetPreResize = true, bool bSetPostResize = true);
 
     // capturing

--- a/src/mpc-hc/PPageShaders.cpp
+++ b/src/mpc-hc/PPageShaders.cpp
@@ -155,8 +155,8 @@ bool CShaderListBox::DeleteCurrentShader()
 
 CString CShaderListBox::GetTitle(const Shader& shader)
 {
-    CString ret = PathUtils::FileName(shader.filePath);
-    if (!PathUtils::IsFile(shader.filePath)) {
+    CString ret = PathUtils::FileName(shader.GetFilePath());
+    if (!PathUtils::IsFile(shader.GetFilePath())) {
         ret += _T(" <not found!>"); // TODO: externalize this string and merge it with the one in PPageExternalFilters
     }
     return ret;
@@ -190,7 +190,7 @@ BOOL CShaderListBox::OnToolTipNotify(UINT id, NMHDR* pNMHDR, LRESULT* pResult)
         int item = (int)pNMHDR->idFrom;
         ASSERT(m_List.size() <= INT_MAX);
         if ((item < GetCount()) && (item < (int)m_List.size())) {
-            text = m_List.at(item).filePath;
+            text = m_List.at(item).GetFilePath();
             ((TOOLTIPTEXT*)pNMHDR)->lpszText = (LPTSTR)(LPCTSTR)text;
         } else {
             ASSERT(FALSE);

--- a/src/mpc-hc/Shaders.cpp
+++ b/src/mpc-hc/Shaders.cpp
@@ -191,10 +191,12 @@ bool Shader::LoadConfig(const CString& path)
     }
 
     for (rapidjson::Value::ConstMemberIterator member = document.MemberBegin(); member != document.MemberEnd(); ++member) {
-        if (member->name == "texture") {
-            rapidjson::Value::ConstMemberIterator id = member->value.FindMember("id");
-            rapidjson::Value::ConstMemberIterator path = member->value.FindMember("path");
-            if (path != member->value.MemberEnd() && id != member->value.MemberEnd()) {
+        rapidjson::Value::ConstMemberIterator id = member->value.FindMember("id");
+        rapidjson::Value::ConstMemberIterator path = member->value.FindMember("path");
+        rapidjson::Value::ConstMemberIterator values = member->value.FindMember("values");
+
+        if (id != member->value.MemberEnd()) {
+            if (path != member->value.MemberEnd()) {
                 ShaderTexture texture;
                 texture.id = id->value.GetInt();
                 texture.path = path->value.GetString();
@@ -226,20 +228,18 @@ bool Shader::LoadConfig(const CString& path)
                 }
 
                 m_Textures.push_back(texture);
-            }
-        } else if (member->name == "float4") {
-            rapidjson::Value::ConstMemberIterator values = member->value.FindMember("values");
-            rapidjson::Value::ConstMemberIterator id = member->value.FindMember("id");
-            if (values != member->value.MemberEnd() && values->value.IsArray() && values->value.Size() == 4 && id != member->value.MemberEnd()) {
-                ShaderParameter param;
-                param.id = id->value.GetInt();
-                memset(param.values, 0, sizeof(float) * 4);
+            } else if (values != member->value.MemberEnd()) {
+                if (values != member->value.MemberEnd() && values->value.IsArray() && values->value.Size() == 4 && id != member->value.MemberEnd()) {
+                    ShaderParameter param;
+                    param.id = id->value.GetInt();
+                    memset(param.values, 0, sizeof(float) * 4);
 
-                for (rapidjson::SizeType comp = 0; comp < values->value.Size(); ++comp) {
-                    param.values[comp] = (float)values->value[comp].GetDouble();
+                    for (rapidjson::SizeType comp = 0; comp < values->value.Size(); ++comp) {
+                        param.values[comp] = (float)values->value[comp].GetDouble();
+                    }
+
+                    m_Parameters.push_back(param);
                 }
-
-                m_Parameters.push_back(param);
             }
         }
     }

--- a/src/mpc-hc/Shaders.cpp
+++ b/src/mpc-hc/Shaders.cpp
@@ -1,5 +1,5 @@
 /*
- * (C) 2013-2014 see Authors.txt
+ * (C) 2013-2016 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -23,51 +23,254 @@
 #include "MainFrm.h"
 #include "mplayerc.h"
 #include "PathUtils.h"
+#include "rapidjson/include/rapidjson/document.h"
+#include "rapidjson/include/rapidjson/error/en.h"
+#include <sstream>
+#include <iostream>
 
 #define SHADER_MAX_FILE_SIZE (4 * 1024 * 1024)
 
-Shader::Shader()
-{
-}
-
 Shader::Shader(const CString& path)
-    : filePath(path)
+    : m_FilePath(path)
 {
+    Reload();
 }
 
 bool Shader::operator==(const Shader& rhs) const
 {
-    return filePath.CompareNoCase(rhs.filePath) == 0;
+    return m_FilePath.CompareNoCase(rhs.m_FilePath) == 0;
 }
 
 bool Shader::IsDefault() const
 {
-    ASSERT(!PathUtils::IsRelative(filePath));
+    ASSERT(!PathUtils::IsRelative(m_FilePath));
     ASSERT(!PathUtils::IsRelative(ShaderList::GetShadersDir()));
-    return PathUtils::IsInDir(filePath, ShaderList::GetShadersDir());
+    return PathUtils::IsInDir(m_FilePath, ShaderList::GetShadersDir());
 }
 
-CStringA Shader::GetCode() const
+bool Shader::IsUsing(const CString& filePath) const
 {
-    CStringA code;
-    if (FILE* fp = _tfsopen(filePath, _T("rb"), _SH_SECURE)) {
-        fseek(fp, 0, SEEK_END);
-        size_t codeSize = ftell(fp);
-        rewind(fp);
-        if (codeSize > SHADER_MAX_FILE_SIZE) {
-            // reject shader code that is larger than SHADER_MAX_FILE_SIZE bytes,
-            // we need to limit it to some sane value in case the user tries to feed MPC-HC
-            // something large and bogus
-            ASSERT(FALSE);
-        } else if (fread(code.GetBufferSetLength((int)codeSize), codeSize, 1, fp) == 1) {
-            code.ReleaseBuffer((int)codeSize);
-        } else {
-            code.ReleaseBuffer(0);
-            ASSERT(FALSE);
+    for (const CString& path : m_Pathes) {
+        if (path.CompareNoCase(filePath) == 0) {
+            return true;
         }
-        VERIFY(fclose(fp) == 0);
     }
-    return code;
+
+    return false;
+}
+
+const CString& Shader::GetFilePath() const
+{
+    return m_FilePath;
+}
+
+const CStringA Shader::GetCode() const
+{
+    return m_Code.c_str();
+}
+
+const std::vector<CString>& Shader::GetPathes() const
+{
+    return m_Pathes;
+}
+
+const std::vector<ShaderTexture>& Shader::GetTextures() const
+{
+    return m_Textures;
+}
+
+const std::vector<ShaderParameter>& Shader::GetParameters() const
+{
+    return m_Parameters;
+}
+
+void Shader::Reload()
+{
+    m_Code.clear();
+    m_Pathes.clear();
+    m_Textures.clear();
+    m_Parameters.clear();
+
+    Load(m_FilePath);
+}
+
+bool Shader::Load(const CString& path)
+{
+    const std::string include_token = "#include";
+    const std::string filePath = CT2CA(path);
+
+    m_Pathes.push_back(path);
+    CFile file;
+    if (!file.Open(path, CFile::modeRead | CFile::typeBinary)) {
+        Log("file is missing : " + filePath);
+        return false;
+    }
+
+    if (file.GetLength() + m_Code.size() >= SHADER_MAX_FILE_SIZE) {
+        Log("file too large : " + filePath);
+        return false;
+    }
+
+    std::string content;
+    content.resize(file.GetLength());
+    if (file.Read(&content[0], file.GetLength()) != file.GetLength()) {
+        Log("failed to read : " + filePath);
+        return false;
+    }
+
+    if (!StripComments(content)) {
+        Log("invalid comments : " + filePath);
+        return false;
+    }
+
+    m_Code.reserve(m_Code.size() + content.size());
+    std::istringstream stream(content);
+    std::string line;
+    while (std::getline(stream, line)) {
+        size_t pos = line.find(include_token);
+        if (pos != std::string::npos) {
+            size_t start = line.find('\"', pos + include_token.size());
+            size_t stop;
+            if (start == std::string::npos) {
+                start = line.find('<', pos + include_token.size());
+                stop = line.find('>', pos + include_token.size());
+            } else {
+                stop = line.find('\"', start + 1);
+            }
+
+            if (start == std::string::npos || stop == std::string::npos) {
+                Log("invalid include : " + line);
+                return false;
+            }
+
+            CString includePath = PathUtils::CombinePaths(PathUtils::DirName(path), CString(line.substr(start + 1, stop - start - 1).c_str()));
+
+            if (!Load(includePath)) {
+                return false;
+            }
+        } else {
+            m_Code += line;
+        }
+        m_Code += '\n';
+    }
+    return LoadConfig(path);
+}
+
+bool Shader::LoadConfig(const CString& path)
+{
+    CString folder = PathUtils::DirName(path);
+    CString configPath = PathUtils::CombinePaths(folder, PathUtils::FileName(path) + SHADERS_CFG);
+    if (!PathUtils::IsFile(configPath)) {
+        return true;
+    }
+    const std::string filePath = CT2CA(configPath);
+
+    m_Pathes.push_back(configPath);
+    CFile file;
+    if (!file.Open(configPath, CFile::modeRead | CFile::osSequentialScan | CFile::typeBinary) || file.GetLength() > SHADER_MAX_FILE_SIZE) {
+        Log("failed to access : " + filePath);
+        return false;
+    }
+
+    std::string content;
+    content.resize(file.GetLength());
+    if (file.Read(&content[0], file.GetLength()) != file.GetLength()) {
+        Log("failed to read : " + filePath);
+        return false;
+    }
+
+    if (!StripComments(content)) {
+        Log("invalid comments : " + filePath);
+        return false;
+    }
+
+    rapidjson::Document document;
+    if (document.Parse(content.c_str()).HasParseError()) {
+        Log(filePath + " : " + rapidjson::GetParseError_En(document.GetParseError()));
+        return false;
+    }
+
+    for (rapidjson::Value::ConstMemberIterator member = document.MemberBegin(); member != document.MemberEnd(); ++member) {
+        if (member->name == "texture") {
+            rapidjson::Value::ConstMemberIterator id = member->value.FindMember("id");
+            rapidjson::Value::ConstMemberIterator path = member->value.FindMember("path");
+            if (path != member->value.MemberEnd() && id != member->value.MemberEnd()) {
+                ShaderTexture texture;
+                texture.id = id->value.GetInt();
+                texture.path = path->value.GetString();
+                texture.path.Replace(_T("/"), _T("\\"));
+
+                if (PathUtils::IsFile(texture.path)) {
+                    m_Pathes.push_back(texture.path);
+                } else {
+                    CString texturePath = PathUtils::CombinePaths(folder, texture.path);
+                    if (PathUtils::IsFile(CString(texturePath))) {
+                        texture.path = texturePath;
+                        m_Pathes.push_back(texture.path);
+                    } else {
+                        Log(std::string(CT2CA(texture.path)) + " not found");
+                    }
+                }
+
+                texture.filter = 3;
+                texture.wrap = 0;
+
+                rapidjson::Value::ConstMemberIterator filter = member->value.FindMember("filter");
+                if (filter != member->value.MemberEnd()) {
+                    texture.filter = filter->value.GetInt();
+                }
+
+                rapidjson::Value::ConstMemberIterator wrap = member->value.FindMember("wrap");
+                if (wrap != member->value.MemberEnd()) {
+                    texture.wrap = filter->value.GetInt();
+                }
+
+                m_Textures.push_back(texture);
+            }
+        } else if (member->name == "float4") {
+            rapidjson::Value::ConstMemberIterator values = member->value.FindMember("values");
+            rapidjson::Value::ConstMemberIterator id = member->value.FindMember("id");
+            if (values != member->value.MemberEnd() && values->value.IsArray() && values->value.Size() == 4 && id != member->value.MemberEnd()) {
+                ShaderParameter param;
+                param.id = id->value.GetInt();
+                memset(param.values, 0, sizeof(float) * 4);
+
+                for (rapidjson::SizeType comp = 0; comp < values->value.Size(); ++comp) {
+                    param.values[comp] = (float)values->value[comp].GetDouble();
+                }
+
+                m_Parameters.push_back(param);
+            }
+        }
+    }
+
+    return true;
+}
+
+bool Shader::StripComments(std::string& code) const
+{
+    size_t pos;
+    while ((pos = code.find("/*")) != std::string::npos) {
+        size_t end = code.find("*/", pos);
+        if (end == -1) {
+            return false;
+        }
+        code.erase(pos, (end - pos) + 2);
+    }
+    while ((pos = code.find("//")) != std::string::npos) {
+        size_t end = code.find('\n', pos);
+        if (end != std::string::npos) {
+            code.erase(pos, end - pos);
+        } else {
+            code.erase(pos);
+        }
+    }
+    return true;
+}
+
+void Shader::Log(std::string message)
+{
+    m_Code += "#error " + message + "\n";
 }
 
 ShaderList::ShaderList()
@@ -94,7 +297,7 @@ CString ShaderList::ToString() const
 {
     CString ret, tok, dir = GetShadersDir();
     for (auto it = cbegin(); it != cend(); ++it) {
-        tok = it->filePath;
+        tok = it->GetFilePath();
         // convert path to relative when possible
         if (PathUtils::IsInDir(tok, dir)) {
             bool rel;
@@ -339,10 +542,14 @@ FileChangeNotifier::FileSet ShaderSelection::ShaderCurrentPreset::GetWatchedList
 {
     FileSet ret;
     for (const auto& shader : m_PreResize) {
-        ret.emplace(shader.filePath);
+        for (const CString& path : shader.GetPathes()) {
+            ret.emplace(path);
+        }
     }
     for (const auto& shader : m_PostResize) {
-        ret.emplace(shader.filePath);
+        for (const CString& path : shader.GetPathes()) {
+            ret.emplace(path);
+        }
     }
     return ret;
 }
@@ -364,16 +571,9 @@ void ShaderSelection::ShaderCurrentPreset::WatchedFilesChanged(const FileSet& ch
 
 void ShaderSelection::ShaderCurrentPreset::WatchedFilesCooldownCallback()
 {
-    bool setPre = false, setPost = false;
-    for (const auto& change : m_changes) {
-        Shader shader(change);
-        if (!setPre && std::find(m_PreResize.begin(), m_PreResize.end(), shader) != std::end(m_PreResize)) {
-            setPre = true;
-        }
-        if (!setPost && std::find(m_PostResize.begin(), m_PostResize.end(), shader) != std::end(m_PostResize)) {
-            setPost = true;
-        }
-    }
+    bool setPre = CheckWatchedFiles(m_PreResize);
+    bool setPost = CheckWatchedFiles(m_PostResize);
+
     if (setPre && setPost) {
         m_eventc.FireEvent(MpcEvent::SHADER_SELECTION_CHANGED);
     } else if (setPre) {
@@ -382,6 +582,30 @@ void ShaderSelection::ShaderCurrentPreset::WatchedFilesCooldownCallback()
         m_eventc.FireEvent(MpcEvent::SHADER_POSTRESIZE_SELECTION_CHANGED);
     }
     m_changes.clear();
+
+    if (setPre || setPost) {
+        UpdateNotifierState();
+    }
+}
+
+bool ShaderSelection::ShaderCurrentPreset::CheckWatchedFiles(ShaderList& shaders)
+{
+    bool ret = false;
+    for (Shader& shader : shaders) {
+        bool modified = false;
+        for (const CString& change : m_changes) {
+            if (shader.IsUsing(change)) {
+                modified = true;
+                break;
+            }
+        }
+
+        if (modified) {
+            ret = true;
+            shader.Reload();
+        }
+    }
+    return ret;
 }
 
 bool ShaderSelection::NextPreset(bool bWrap/* = true*/)

--- a/src/mpc-hc/Shaders.h
+++ b/src/mpc-hc/Shaders.h
@@ -1,5 +1,5 @@
 /*
- * (C) 2013-2014 see Authors.txt
+ * (C) 2013-2016 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -29,13 +29,48 @@
 
 #include "EventDispatcher.h"
 
-struct Shader {
-    Shader();
+struct ShaderTexture {
+    int id;
+    CString path;
+    int filter;
+    int wrap;
+};
+
+struct ShaderParameter {
+    int id;
+    float values[4];
+};
+
+class Shader
+{
+public:
     Shader(const CString& path);
-    CString filePath;
+
     bool operator==(const Shader& rhs) const;
     bool IsDefault() const;
-    CStringA GetCode() const;
+    bool IsUsing(const CString& filePath) const;
+
+    const CString& GetFilePath() const;
+    const CStringA GetCode() const;
+    const std::vector<CString>& GetPathes() const;
+    const std::vector<ShaderTexture>& GetTextures() const;
+    const std::vector<ShaderParameter>& GetParameters() const;
+
+    void Reload();
+
+private:
+
+    bool Load(const CString& path);
+    bool LoadConfig(const CString& path);
+
+    bool StripComments(std::string& code) const;
+    void Log(std::string message);
+
+    CString m_FilePath;
+    std::string m_Code;
+    std::vector<CString> m_Pathes;
+    std::vector<ShaderTexture> m_Textures;
+    std::vector<ShaderParameter> m_Parameters;
 };
 
 class ShaderList : public std::vector<Shader>
@@ -118,6 +153,7 @@ protected:
         virtual FileSet GetWatchedList() override;
         virtual void WatchedFilesChanged(const FileSet& changes) override;
         void WatchedFilesCooldownCallback();
+        bool CheckWatchedFiles(ShaderList& shaders);
         FileSet m_changes;
         EventClient m_eventc;
     };

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -81,7 +81,7 @@
       <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>d3d9.lib;delayimp.lib;dsound.lib;dxguid.lib;GdiPlus.lib;Psapi.lib;SetupAPI.lib;UxTheme.lib;Vfw32.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d9.lib;d3dx9.lib;delayimp.lib;dsound.lib;dxguid.lib;GdiPlus.lib;Psapi.lib;SetupAPI.lib;UxTheme.lib;Vfw32.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>d3d9.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
     </Link>


### PR DESCRIPTION
Features :
- shader configuration in json format
- support of external images / textures (with filtering and wrap modes), and float parameters
- support of includes
- support of C style comments in .json
- automatic reload if either shader, config files, included files, images change
- `ISubPicShaderPresenter` interface to retrieve the parameters, call just after SetPixelShader

[Sample shader for testing purpose](http://on-situ.com/mpc-hc/shader_json_sample.7z)
