### PR TITLE
Readme & Authors: some corrections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,7 +85,7 @@ MPC-HC makes use of the following third-party code:
 | TreePropSheet     | -                         | http://www.codeproject.com/Articles/3709/ |
 | UnRAR             | freeware                  | http://www.rarlab.com/rar_add.htm |
 | VirtualDub        | GPLv2+                    | http://www.virtualdub.org/ |
-| XmlRpcC4Win       | LGPLv2                    | https://github.com/drtimcooper/XmlRpc4Win |
+| XmlRpc4Win        | LGPLv2                    | https://github.com/drtimcooper/XmlRpc4Win |
 | ZenLib            | zlib License              | https://sourceforge.net/projects/zenlib/ |
 | zita-resampler    | GPLv3                     | http://kokkinizita.linuxaudio.org/linuxaudio/ |
 | zlib              | zlib License              | http://zlib.net/ |

--- a/docs/Authors.txt
+++ b/docs/Authors.txt
@@ -39,7 +39,7 @@ xpc1000                 <xpc1000@users.sourceforge.net>         Code
 Translators:
 ------------
 Translations are now handled using Transifex, a web-based translation platform. An up-to-date list
-of translators involved for each language can be found on https://www.transifex.com/projects/p/mpc-hc/.
+of translators involved for each language can be found on https://www.transifex.com/mpc-hc/mpc-hc/.
 
 Translators (pre-Transifex era):
 ------------

--- a/docs/Readme.txt
+++ b/docs/Readme.txt
@@ -74,7 +74,7 @@ tinyxml2            zlib License                http://www.grinninglizard.com/ti
 TreePropSheet       -                           http://www.codeproject.com/Articles/3709/
 UnRAR               freeware                    http://www.rarlab.com/rar_add.htm
 VirtualDub          GPLv2+                      http://www.virtualdub.org/
-XmlRpcC4Win         LGPLv2                      https://github.com/drtimcooper/XmlRpc4Win
+XmlRpc4Win          LGPLv2                      https://github.com/drtimcooper/XmlRpc4Win
 ZenLib              zlib License                https://sourceforge.net/projects/zenlib/
 zita-resampler      GPLv3                       http://kokkinizita.linuxaudio.org/linuxaudio/
 zlib                zlib License                http://zlib.net/


### PR DESCRIPTION
That's all that I could find and made some correction

- On SourceForge, its name is XmlRpcC4Win, on GitHub it's XmlRpc4Win. Not sure which one is right though.
- Changed Transifex link to direct link.

That's all. regards. :)