### PR TITLE
If no index with hwgpu is sent, leave iLAVGPUDevice as is

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -2169,7 +2169,7 @@ void CAppSettings::ParseCommandLine(CAtlList<CString>& cmdln)
                 nCLSwitches |= CLSW_MONITOROFF;
             } else if (sw == _T("playnext")) {
                 nCLSwitches |= CLSW_PLAYNEXT;
-            } else if (sw == _T("hwgpu")) {
+            } else if (sw == _T("hwgpu") && pos) {
                 iLAVGPUDevice = _tcstol(cmdln.GetNext(pos), nullptr, 10);
             } else {
                 nCLSwitches |= CLSW_HELP | CLSW_UNRECOGNIZEDSWITCH;


### PR DESCRIPTION
Fixes #5881 by keeping iLAVGPUDevice at default value if no additional
argument is sent with '/hwgpu'