### PR TITLE
fix: textsub renders nothing in avisynth.

### DIFF
--- a/src/filters/transform/VSFilter/plugins.cpp
+++ b/src/filters/transform/VSFilter/plugins.cpp
@@ -86,7 +86,8 @@ namespace Plugin
 
             if (!m_pSubPicQueue) {
                 CComPtr<ISubPicAllocator> pAllocator = DEBUG_NEW CMemSubPicAllocator(dst.type, size);
-
+                pAllocator->SetCurVidRect(CRect(CPoint(), size));
+                
                 HRESULT hr = E_FAIL;
                 if (!(m_pSubPicQueue = DEBUG_NEW CSubPicQueueNoThread(SubPicQueueSettings(0, 0, false, 50, 100, false), pAllocator, &hr)) || FAILED(hr)) {
                     m_pSubPicQueue = nullptr;


### PR DESCRIPTION
when used as filter in avisynth, it renders nothing in video.