### PR TITLE
Fix hash calculation for files with Unicode paths.

### DIFF
--- a/docs/Changelog.txt
+++ b/docs/Changelog.txt
@@ -14,3 +14,4 @@ next version - not released yet
 * Updated sanear to v0.3
 ! Ticket #2539: Subtitle downloader dialog could be opened on disabled monitor
 ! Fix text subtitle rendering in Avisynth
+! Fix hash calculation for files with Unicode paths. This fixes search on OpenSubtitles for such files.

--- a/src/mpc-hc/SubtitlesProvider.cpp
+++ b/src/mpc-hc/SubtitlesProvider.cpp
@@ -434,7 +434,7 @@ SRESULT SubDB::Hash(SubtitlesInfo& pFileInfo)
     } else {
         CFile file;
         CFileException fileException;
-        if (file.Open(CString(pFileInfo.filePath.c_str()),
+        if (file.Open(CString(pFileInfo.filePathW.c_str()),
                       CFile::modeRead | CFile::osSequentialScan | CFile::shareDenyNone | CFile::typeBinary,
                       &fileException)) {
             file.Read(&buffer[0], PROBE_SIZE);

--- a/src/mpc-hc/SubtitlesProviders.cpp
+++ b/src/mpc-hc/SubtitlesProviders.cpp
@@ -246,7 +246,7 @@ static constexpr LPCTSTR log_format =
     _T("releaseGroup=\"%S\"\n")                                       \
     _T("discNumber=%d");
 
-HRESULT SubtitlesInfo::GetFileInfo(const std::string& sFileName /*= std::string()*/)
+HRESULT SubtitlesInfo::GetFileInfo(const std::wstring& sFileName /*= std::wstring()*/)
 {
     if (sFileName.empty()) {
         CMainFrame& MainFrame = *(CMainFrame*)(AfxGetMyApp()->GetMainWnd());
@@ -264,6 +264,7 @@ HRESULT SubtitlesInfo::GetFileInfo(const std::string& sFileName /*= std::string(
             if (FAILED(MainFrame.m_pFSF->GetCurFile(&name, nullptr))) {
                 return E_FAIL;
             }
+            filePathW = name;
             filePath = UTF16To8(name);
             //fileName = UTF16To8(name);
             CoTaskMemFree(name);
@@ -282,6 +283,7 @@ HRESULT SubtitlesInfo::GetFileInfo(const std::string& sFileName /*= std::string(
                     return E_FAIL;
                 }
 
+                filePathW = _filePath;
                 filePath = UTF16To8(_filePath);
                 fileSize = file.GetLength();
             }
@@ -303,7 +305,8 @@ HRESULT SubtitlesInfo::GetFileInfo(const std::string& sFileName /*= std::string(
             }
         }
     } else {
-        filePath = sFileName;
+        filePath = UTF16To8(sFileName.c_str());
+        filePathW = sFileName;
     }
 
     auto fPath = UTF8To16(filePath.c_str());
@@ -890,7 +893,7 @@ void SubtitlesThread::Set(SubtitlesInfo& pSubtitlesInfo)
     if (!_title.empty()) {
         pSubtitlesInfo.title.clear();
     }
-    pSubtitlesInfo.GetFileInfo(pSubtitlesInfo.fileName);
+    pSubtitlesInfo.GetFileInfo(pSubtitlesInfo.filePathW);
 
     //iter.score = 0; //LevenshteinDistance(m_pFileInfo.fileName, string_(subtitlesName)) * 100;
 

--- a/src/mpc-hc/SubtitlesProviders.h
+++ b/src/mpc-hc/SubtitlesProviders.h
@@ -85,7 +85,7 @@ struct SubtitlesInfo {
         , framesNumber(INT_ERROR)
         , lengthMs(ULONGLONG_ERROR) {}
     bool operator<(const SubtitlesInfo& rhs) const { return score > rhs.score; }
-    HRESULT GetFileInfo(const std::string& sFileName = std::string());
+    HRESULT GetFileInfo(const std::wstring& sFileName = std::wstring());
     void Download(bool bActivate);
     void OpenUrl() const;
     std::shared_ptr<SubtitlesProvider> Provider() const { return fileProvider; }
@@ -133,6 +133,7 @@ private:
     DWORD score;
 public:
     // file properties
+    std::wstring filePathW;
     std::string filePath;
     std::string fileName;
     std::string fileExtension;

--- a/src/mpc-hc/SubtitlesProvidersUtils.cpp
+++ b/src/mpc-hc/SubtitlesProvidersUtils.cpp
@@ -803,7 +803,7 @@ UINT64 SubtitlesProvidersUtils::GenerateOSHash(SubtitlesInfo& pFileInfo)
     } else {
         CFile file;
         CFileException fileException;
-        if (file.Open(CString(pFileInfo.filePath.c_str()),
+        if (file.Open(CString(pFileInfo.filePathW.c_str()),
                       CFile::modeRead | CFile::osSequentialScan | CFile::shareDenyNone | CFile::typeBinary, &fileException)) {
             for (UINT64 tmp = 0, i = 0; i < PROBE_SIZE / sizeof(tmp) && file.Read(&tmp, sizeof(tmp)); fileHash += tmp, ++i);
             file.Seek(std::max(0ui64, pFileInfo.fileSize - PROBE_SIZE), CFile::begin);


### PR DESCRIPTION
 This fixes search on OpenSubtitles for such files.

Fixes #6231.