### PR TITLE
Fallback exception handling for when crash reporter is unavailable

### DIFF
--- a/docs/Changelog.txt
+++ b/docs/Changelog.txt
@@ -10,6 +10,7 @@ Legend:
 
 next version - not released yet
 ===============================
++ Added fallback exception handler for when DrDump Crash Reporter is unavailable
 * Updated Little CMS to v2.9 (4be486f)
 * Updated sanear to v0.3
 ! Subtitle downloader dialog could be opened on disabled monitor

--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -25,6 +25,7 @@
 #include "FGFilter.h"
 #include "FakeFilterMapper2.h"
 #include "FileAssoc.h"
+#include "ExceptionHandler.h"
 #include "SysVersion.h"
 #include "PathUtils.h"
 #include "Translations.h"
@@ -2172,6 +2173,7 @@ void CAppSettings::ParseCommandLine(CAtlList<CString>& cmdln)
                 fShowDebugInfo = true;
             } else if (sw == _T("nocrashreporter")) {
                 CrashReporter::Disable();
+                MPCExceptionHandler::Enable();
             } else if (sw == _T("audiorenderer") && pos) {
                 SetAudioRenderer(_ttoi(cmdln.GetNext(pos)));
             } else if (sw == _T("shaderpreset") && pos) {

--- a/src/mpc-hc/ExceptionHandler.cpp
+++ b/src/mpc-hc/ExceptionHandler.cpp
@@ -1,0 +1,216 @@
+/*
+ * (C) 2017 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "ExceptionHandler.h"
+#include <windows.h>
+#include <psapi.h>
+
+#ifndef _DEBUG
+
+LPCWSTR GetExceptionName(DWORD code)
+{
+    switch (code) {
+        case EXCEPTION_ACCESS_VIOLATION:
+            return _T("ACCESS VIOLATION");
+        case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+            return _T("ARRAY BOUNDS EXCEEDED");
+        case EXCEPTION_BREAKPOINT:
+            return _T("BREAKPOINT");
+        case EXCEPTION_DATATYPE_MISALIGNMENT:
+            return _T("DATATYPE MISALIGNMENT");
+        case EXCEPTION_FLT_DENORMAL_OPERAND:
+            return _T("FLT DENORMAL OPERAND");
+        case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+            return _T("FLT DIVIDE BY ZERO");
+        case EXCEPTION_FLT_INEXACT_RESULT:
+            return _T("FLT INEXACT RESULT");
+        case EXCEPTION_FLT_INVALID_OPERATION:
+            return _T("FLT INVALID OPERATION");
+        case EXCEPTION_FLT_OVERFLOW:
+            return _T("FLT OVERFLOW");
+        case EXCEPTION_FLT_STACK_CHECK:
+            return _T("FLT STACK CHECK");
+        case EXCEPTION_FLT_UNDERFLOW:
+            return _T("FLT UNDERFLOW");
+        case EXCEPTION_GUARD_PAGE:
+            return _T("GUARD PAGE");
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+            return _T("ILLEGAL_INSTRUCTION");
+        case EXCEPTION_IN_PAGE_ERROR:
+            return _T("IN PAGE ERROR");
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+            return _T("INT DIVIDE BY ZERO");
+        case EXCEPTION_INT_OVERFLOW:
+            return _T("INT OVERFLOW");
+        case EXCEPTION_INVALID_DISPOSITION:
+            return _T("INVALID DISPOSITION");
+        case EXCEPTION_INVALID_HANDLE:
+            return _T("INVALID HANDLE");
+        case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+            return _T("NONCONTINUABLE EXCEPTION");
+        case EXCEPTION_PRIV_INSTRUCTION:
+            return _T("PRIV INSTRUCTION");
+        case EXCEPTION_SINGLE_STEP:
+            return _T("SINGLE STEP");
+        case EXCEPTION_STACK_OVERFLOW:
+            return _T("STACK OVERFLOW");
+        case 0xE06D7363:
+            return _T("UNDEFINED C++ EXCEPTION");
+        default:
+            return _T("[UNKNOWN]");
+    }
+}
+
+HMODULE GetExceptionModule(LPVOID address, LPWSTR moduleName)
+{
+    HMODULE moduleList[1024];
+    DWORD sizeNeeded = 0;
+    if (!EnumProcessModules(GetCurrentProcess(), moduleList, sizeof(moduleList), &sizeNeeded) || sizeNeeded > sizeof(moduleList)) {
+        return nullptr;
+    }
+
+    int curModule = -1;
+    for (DWORD i = 0; i < (sizeNeeded / sizeof(HMODULE)); ++i) {
+        if (moduleList[i] < address) {
+            if (curModule == -1) {
+                curModule = i;
+            } else {
+                if (moduleList[curModule] < moduleList[i]) {
+                    curModule = i;
+                }
+            }
+        }
+    }
+
+    if (curModule == -1) {
+        return nullptr;
+    }
+
+    if (!GetModuleFileName(moduleList[curModule], moduleName, MAX_PATH)) {
+        return nullptr;
+    }
+
+    return moduleList[curModule];
+}
+
+void HandleCommonException(LPEXCEPTION_POINTERS exceptionInfo)
+{
+    wchar_t message[MAX_PATH + 255];
+    wchar_t module[MAX_PATH];
+    wchar_t* moduleName = nullptr;
+    if (GetExceptionModule(exceptionInfo->ExceptionRecord->ExceptionAddress, module)) {
+        moduleName = module;
+    } else {
+        moduleName = _T("[UNKNOWN]");
+    }
+
+    uint64_t codeBase = (uint64_t)GetModuleHandle(NULL);
+    uint64_t offset   = (uint64_t)exceptionInfo->ExceptionRecord->ExceptionAddress - codeBase;
+
+    swprintf_s(message, _countof(message), _T(\
+                                                              "An error has occurred. MPC-HC will close now.\n\n"\
+                                                              "Exception:\n%s\n\n"\
+                                                              "Crashing module:\n%s\n"\
+                                                              "Offset: 0x%I64X, Codebase: 0x%I64X\n\n"),
+               GetExceptionName(exceptionInfo->ExceptionRecord->ExceptionCode),
+               moduleName,
+               offset,
+               codeBase);
+
+    MessageBox(AfxGetApp()->GetMainWnd()->GetSafeHwnd(), message, _T("Unexpected error"), MB_OK | MB_TOPMOST | MB_SETFOREGROUND | MB_SYSTEMMODAL);
+}
+
+void HandleAccessViolation(LPEXCEPTION_POINTERS exceptionInfo)
+{
+    wchar_t message[MAX_PATH + 255];
+    wchar_t module[MAX_PATH];
+    wchar_t* moduleName = NULL;
+    if (GetExceptionModule(exceptionInfo->ExceptionRecord->ExceptionAddress, module)) {
+        moduleName = module;
+    } else {
+        moduleName = _T("[UNKNOWN]");
+    }
+
+    uint64_t codeBase = (uint64_t)GetModuleHandle(NULL);
+    uint64_t offset   = (uint64_t)exceptionInfo->ExceptionRecord->ExceptionAddress - codeBase;
+
+    wchar_t* accessType = NULL;
+    switch (exceptionInfo->ExceptionRecord->ExceptionInformation[0]) {
+        case 0:
+            accessType = _T("read");
+            break;
+        case 1:
+            accessType = _T("write");
+            break;
+        case 2:
+            accessType = _T("execute");
+            break;
+        default:
+            accessType = _T("[UNKNOWN]");
+            break;
+    }
+
+    swprintf_s(message, _countof(message), _T(\
+                                                              "An error has occurred. MPC-HC will close now.\n\n"\
+                                                              "Exception:\n%s\n\n"\
+                                                              "Crashing module:\n%s\n"\
+                                                              "Offset: 0x%I64X, Codebase: 0x%I64X\n"\
+                                                              "The thread %u tried to %s memory at address 0x%IX\n\n"),
+               GetExceptionName(exceptionInfo->ExceptionRecord->ExceptionCode),
+               moduleName,
+               offset,
+               codeBase,
+               GetCurrentThreadId(),
+               accessType,
+               exceptionInfo->ExceptionRecord->ExceptionInformation[1]);
+
+    MessageBox(AfxGetApp()->GetMainWnd()->GetSafeHwnd(), message, _T("Unexpected error"), MB_OK | MB_TOPMOST | MB_SETFOREGROUND | MB_SYSTEMMODAL);
+}
+
+LONG WINAPI UnhandledException(LPEXCEPTION_POINTERS exceptionInfo)
+{
+    switch (exceptionInfo->ExceptionRecord->ExceptionCode) {
+
+        case EXCEPTION_ACCESS_VIOLATION:
+            HandleAccessViolation(exceptionInfo);
+            break;
+        default:
+            HandleCommonException(exceptionInfo);
+            break;
+    }
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
+void MPCExceptionHandler::Enable()
+{
+#ifndef _DEBUG
+    SetUnhandledExceptionFilter(UnhandledException);
+#endif
+};
+
+void MPCExceptionHandler::Disable()
+{
+#ifndef _DEBUG
+    SetUnhandledExceptionFilter(nullptr);
+#endif
+};

--- a/src/mpc-hc/ExceptionHandler.h
+++ b/src/mpc-hc/ExceptionHandler.h
@@ -1,0 +1,27 @@
+/*
+ * (C) 2017 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+namespace MPCExceptionHandler
+{
+    void Enable();
+    void Disable();
+};

--- a/src/mpc-hc/mpc-hc.vcxproj
+++ b/src/mpc-hc/mpc-hc.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="EditListEditor.cpp" />
     <ClCompile Include="EditWithButton.cpp" />
     <ClCompile Include="EventDispatcher.cpp" />
+    <ClCompile Include="ExceptionHandler.cpp" />
     <ClCompile Include="FakeFilterMapper2.cpp" />
     <ClCompile Include="FavoriteAddDlg.cpp" />
     <ClCompile Include="FavoriteOrganizeDlg.cpp" />
@@ -294,6 +295,7 @@
     <ClInclude Include="EditListEditor.h" />
     <ClInclude Include="EditWithButton.h" />
     <ClInclude Include="EventDispatcher.h" />
+    <ClInclude Include="ExceptionHandler.h" />
     <ClInclude Include="FakeFilterMapper2.h" />
     <ClInclude Include="FavoriteAddDlg.h" />
     <ClInclude Include="FavoriteOrganizeDlg.h" />

--- a/src/mpc-hc/mpc-hc.vcxproj.filters
+++ b/src/mpc-hc/mpc-hc.vcxproj.filters
@@ -394,6 +394,7 @@
     <ClCompile Include="DeinterlacerFilter.cpp">
       <Filter>Graph</Filter>
     </ClCompile>
+    <ClCompile Include="ExceptionHandler.cpp" />
     <ClCompile Include="FakeFilterMapper2.cpp">
       <Filter>Graph</Filter>
     </ClCompile>
@@ -787,6 +788,7 @@
     <ClInclude Include="DeinterlacerFilter.h">
       <Filter>Graph</Filter>
     </ClInclude>
+    <ClInclude Include="ExceptionHandler.h" />
     <ClInclude Include="FakeFilterMapper2.h">
       <Filter>Graph</Filter>
     </ClInclude>

--- a/src/mpc-hc/mplayerc.cpp
+++ b/src/mpc-hc/mplayerc.cpp
@@ -45,6 +45,7 @@
 #include <atlsync.h>
 #include <winternl.h>
 #include <regex>
+#include "ExceptionHandler.h"
 
 #define HOOKS_BUGS_URL _T("https://trac.mpc-hc.org/ticket/3739")
 
@@ -1459,6 +1460,9 @@ BOOL CMPlayerCApp::InitInstance()
     // At this point we have not hooked this function yet so we get the real result
     if (!IsDebuggerPresent()) {
         CrashReporter::Enable();
+        if (!CrashReporter::IsEnabled()) {
+            MPCExceptionHandler::Enable();
+        }
     }
 
     if (!HeapSetInformation(nullptr, HeapEnableTerminationOnCorruption, nullptr, 0)) {


### PR DESCRIPTION
This will be used if user removes CrashReporter folder. It is also useful for custom/unofficial builds, for which DrDump is useless.

Additionally I could add an option to the installer to not install CrashReporter. This was requested by users. Opinions welcome.

@XhmikosR, could you give access to DrDump? I would like to redirect some common third party crashes to tickets on Trac, where I explain how user can solve those problems.

If any of the new volunteers have good debugging skills with Visual Studio, perhaps they could attempt to fix any of the top crashes in mpc-hc.
