### PR TITLE
Add setting for custom filename on save image

### DIFF
--- a/src/mpc-hc/AppSettings.cpp
+++ b/src/mpc-hc/AppSettings.cpp
@@ -1015,6 +1015,7 @@ void CAppSettings::SaveSettings()
 
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTPATH, strSnapshotPath);
     pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTEXT, strSnapshotExt);
+    pApp->WriteProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTNAMEFORMAT, strSnapshotNameFormat);
 
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_THUMBROWS, iThumbRows);
     pApp->WriteProfileInt(IDS_R_SETTINGS, IDS_RS_THUMBCOLS, iThumbCols);
@@ -1680,6 +1681,7 @@ void CAppSettings::LoadSettings()
     }
     strSnapshotPath = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTPATH, MyPictures);
     strSnapshotExt = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTEXT, _T(".jpg"));
+    strSnapshotNameFormat = pApp->GetProfileString(IDS_R_SETTINGS, IDS_RS_SNAPSHOTNAMEFORMAT, _T("%f_snapshot_%t_[%Y.%m.%d_%H.%M.%S]"));
 
     iThumbRows = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_THUMBROWS, 4);
     iThumbCols = pApp->GetProfileInt(IDS_R_SETTINGS, IDS_RS_THUMBCOLS, 4);

--- a/src/mpc-hc/AppSettings.h
+++ b/src/mpc-hc/AppSettings.h
@@ -666,7 +666,7 @@ public:
     bool            bFavRememberPos;
     bool            bFavRelativeDrive;
     // Save Image...
-    CString         strSnapshotPath, strSnapshotExt;
+    CString         strSnapshotPath, strSnapshotExt, strSnapshotNameFormat;
     // Save Thumbnails...
     int             iThumbRows, iThumbCols, iThumbWidth;
     // Save Subtitle

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4883,9 +4883,21 @@ static void ReplaceInvalidFormatSpecifiers(CString& str)
     }
 }
 
-static CString MakeSnapshotFileName(const CString& title, const CString& vidPos = _T(""))
+CString CMainFrame::MakeSnapshotFileName()
 {
     const auto& settings = AfxGetAppSettings();
+
+    CString title;
+    CString vidPos;
+    if (GetPlaybackMode() == PM_FILE) {
+        title = GetFileName();
+        vidPos = GetVidPos();
+    } else if (GetPlaybackMode() == PM_DVD) {
+        title = GetFileName();
+        vidPos = GetVidPos();
+    } else if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
+        title = m_pDVBState->sChannelName;
+    }
 
     CString formatString = settings.strSnapshotNameFormat;
     CString escapedTitle = EscapeFormatSpecifiers(title);
@@ -4952,16 +4964,8 @@ void CMainFrame::OnFileSaveImage()
         return;
     }
 
+    CString snapshotName = MakeSnapshotFileName();
     CPath psrc(s.strSnapshotPath);
-
-    CString snapshotName = _T("snapshot");
-    if (GetPlaybackMode() == PM_FILE) {
-        snapshotName = MakeSnapshotFileName(GetFileName(), GetVidPos());
-    } else if (GetPlaybackMode() == PM_DVD) {
-        snapshotName = MakeSnapshotFileName(GetFileName(), GetVidPos());
-    } else if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        snapshotName = MakeSnapshotFileName(m_pDVBState->sChannelName);
-    }
     psrc.Combine(s.strSnapshotPath, snapshotName);
 
     CSaveImageDialog fd(s.nJpegQuality, nullptr, (LPCTSTR)psrc,
@@ -5022,15 +5026,7 @@ void CMainFrame::OnFileSaveImageAuto()
         return;
     }
 
-    CString snapshotName = _T("snapshot");
-    if (GetPlaybackMode() == PM_FILE) {
-        snapshotName = MakeSnapshotFileName(GetFileName(), GetVidPos());
-    } else if (GetPlaybackMode() == PM_DVD) {
-        snapshotName = MakeSnapshotFileName(GetFileName(), GetVidPos());
-    } else if (GetPlaybackMode() == PM_DIGITAL_CAPTURE) {
-        snapshotName = MakeSnapshotFileName(m_pDVBState->sChannelName);
-    }
-
+    CString snapshotName = MakeSnapshotFileName();
     CString fn;
     fn.Format(_T("%s\\%s"), s.strSnapshotPath, snapshotName);
     SaveImage(fn);
@@ -5054,7 +5050,7 @@ void CMainFrame::OnFileSaveThumbnails()
     CPath psrc(s.strSnapshotPath);
     CString snapshotName = _T("snapshot");
     if (GetPlaybackMode() == PM_FILE) {
-        snapshotName = MakeSnapshotFileName(GetFileName());
+        snapshotName = MakeSnapshotFileName();
     } else {
         ASSERT(FALSE);
     }

--- a/src/mpc-hc/MainFrm.h
+++ b/src/mpc-hc/MainFrm.h
@@ -1021,6 +1021,7 @@ public:
     void        JumpOfNSeconds(int seconds);
 
     CString GetVidPos() const;
+    CString MakeSnapshotFileName();
 
     CComPtr<ITaskbarList3> m_pTaskbarList;
     HRESULT CreateThumbnailToolbar();

--- a/src/mpc-hc/PPageAdvanced.cpp
+++ b/src/mpc-hc/PPageAdvanced.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 2014-2016 see Authors.txt
+* (C) 2014-2017 see Authors.txt
 *
 * This file is part of MPC-HC.
 *
@@ -143,6 +143,7 @@ void CPPageAdvanced::InitSettings()
     addIntItem(DEFAULT_TOOLBAR_SIZE, IDS_RS_DEFAULTTOOLBARSIZE, 24, s.nDefaultToolbarSize,
                std::make_pair(16, 128), StrRes(IDS_PPAGEADVANCED_DEFAULTTOOLBARSIZE));
     addBoolItem(USE_LEGACY_TOOLBAR, IDS_RS_USE_LEGACY_TOOLBAR, false, s.bUseLegacyToolbar, StrRes(IDS_PPAGEADVANCED_USE_LEGACY_TOOLBAR));
+    addCStringItem(SNAPSHOT_NAME_FORMAT, IDS_RS_SNAPSHOTNAMEFORMAT, _T("%f_snapshot_%t_[%Y.%m.%d_%H.%M.%S]"), s.strSnapshotNameFormat, StrRes(IDS_PPAGEADVANCED_SNAPSHOT_NAME_FORMAT));
 }
 
 BOOL CPPageAdvanced::OnApply()
@@ -344,7 +345,7 @@ void CPPageAdvanced::OnLvnItemchangedList(NMHDR* pNMHDR, LRESULT* pResult)
                 m_spinButtonCtrl.ShowWindow(SW_SHOW);
                 GetDlgItem(IDC_EDIT1)->ShowWindow(SW_SHOW);
             } else if (auto pItemCString = std::dynamic_pointer_cast<SettingsCString>(pItem)) {
-                setDialogItemsVisibility({ IDC_COMBO1, IDC_RADIO1, IDC_RADIO2, IDC_BUTTON1, IDC_SPIN1 }, SW_HIDE);
+                setDialogItemsVisibility({ IDC_COMBO1, IDC_RADIO1, IDC_RADIO2, IDC_SPIN1 }, SW_HIDE);
                 GetDlgItem(IDC_EDIT1)->ModifyStyle(ES_NUMBER, 0, 0);
                 SetDlgItemText(IDC_EDIT1, pItemCString->GetValue());
                 GetDlgItem(IDC_EDIT1)->ShowWindow(SW_SHOW);

--- a/src/mpc-hc/PPageAdvanced.h
+++ b/src/mpc-hc/PPageAdvanced.h
@@ -1,5 +1,5 @@
 /*
-* (C) 2015-2016 see Authors.txt
+* (C) 2015-2017 see Authors.txt
 *
 * This file is part of MPC-HC.
 *
@@ -148,6 +148,7 @@ private:
         AUTO_DOWNLOAD_SCORE_SERIES,
         DEFAULT_TOOLBAR_SIZE,
         USE_LEGACY_TOOLBAR,
+        SNAPSHOT_NAME_FORMAT,
     };
 
     enum {

--- a/src/mpc-hc/SettingsDefines.h
+++ b/src/mpc-hc/SettingsDefines.h
@@ -1,5 +1,5 @@
 /*
- * (C) 2009-2016 see Authors.txt
+ * (C) 2009-2017 see Authors.txt
  *
  * This file is part of MPC-HC.
  *
@@ -191,6 +191,7 @@
 #define IDS_RS_SNAPSHOTPATH                 _T("SnapshotPath")
 #define IDS_RS_PRIORITY                     _T("Priority")
 #define IDS_RS_SNAPSHOTEXT                  _T("SnapshotExt")
+#define IDS_RS_SNAPSHOTNAMEFORMAT           _T("SnapshotNameFormat")
 #define IDS_RS_LAUNCHFULLSCREEN             _T("LaunchFullScreen")
 #define IDS_RS_WEBROOT                      _T("WebRoot")
 #define IDS_RS_WEBSERVERLOCALHOSTONLY       _T("WebServerLocalhostOnly")

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3547,7 +3547,6 @@ STRINGTABLE
 BEGIN
     IDS_SUBTITLE_RENDERER_VS_FILTER "VSFilter / DirectVobSub"
     IDS_SUBTITLE_RENDERER_XY_SUB_FILTER "XySubFilter"
-    IDS_SUBTITLE_RENDERER_ASS_FILTER "AssFilter"
     IDS_SUBDL_DLG_PROVIDER_COL "Provider"
     IDS_SUBDL_DLG_HI_COL    "Hearing Impaired"
     IDS_SUBDL_DLG_DOWNLOADS_COL "Downloads"
@@ -3562,6 +3561,28 @@ BEGIN
     IDS_SUBUL_DLG_USERNAME_COL "Username"
     IDS_SUBUL_DLG_STATUS_COL "Status"
     IDS_SUBUL_DLG_STATUS_READY "Ready..."
+END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_PNS             "/pns ""name""\tSpecify Pan & Scan preset name to use"
+    IDS_CMD_ICONASSOC       "/iconsassoc\tReassociate format icons"
+    IDS_CMD_NOFOCUS         "/nofocus\t\tOpen MPC-HC in background"
+    IDS_CMD_WEBPORT         "/webport N\tStart web interface on specified port"
+    IDS_CMD_DEBUG           "/debug\t\tShow debug information in OSD"
+    IDS_CMD_NOCRASHREPORTER "/nocrashreporter\tDisable the crash reporter"
+    IDS_CMD_SLAVE           "/slave ""hWnd""\tUse MPC-HC as slave"
+    IDS_CMD_HWGPU           "/hwgpu ""index""\tSet the index of the GPU used for hardware decoding.\n\t\tOnly available for CUVID and DXVA2 (copy-back)"
+    IDS_CMD_RESET           "/reset\t\tRestore default settings"
+    IDS_CMD_HELP            "/help /h /?\tShow help about command line switches"
+    IDS_PPAGEADVANCED_SCORE "Threshold value for subtitles score which are going to be automatically downloaded. Higher values means that more accurately matched subtitles will be loaded, lower values could result in incorrect subtitles being loaded, but there is no one perfect value. Pick one that works best for you."
+    IDS_PPAGE_FS_CLN_AUDIO_DELAY "Audio Delay (ms)"
+    IDS_PPAGEADVANCED_DEFAULTTOOLBARSIZE 
+                            "Size in pixels of the default toolbar."
+    IDS_PPAGEADVANCED_USE_LEGACY_TOOLBAR 
+                            "Use legacy toolbar instead of new vectorized one."
+    IDS_SUBTITLE_RENDERER_ASS_FILTER "AssFilter"
+    IDS_SUBMENU_COPYURL     "Copy URL"
 END
 
 STRINGTABLE
@@ -3625,18 +3646,22 @@ BEGIN
     IDS_CMD_LOCK            "/lock\t\tLock workstation after playback"
     IDS_CMD_MONITOROFF      "/monitoroff\tTurn off the monitor after playback"
     IDS_CMD_PLAYNEXT        "/playnext\t\tOpen next file in the folder after playback"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_VIEWPRESET      "/viewpreset N\tStart with specific preset,\n\t\twhere N is either ""1"" Minimal, ""2"" Compact or ""3"" Normal"
     IDS_CMD_MUTE            "/mute\t\tMute the audio"
+    IDS_CMD_VOLUME          "/volume N\tSet Volume, where N is a range from 0 to 100"
 END
 
 STRINGTABLE
 BEGIN
     IDS_CMD_FULLSCREEN      "/fullscreen\tStart in fullscreen mode"
-    IDS_CMD_VIEWPRESET      "/viewpreset N\tStart with specific preset,\n\t\twhere N is either ""1"" Minimal, ""2"" Compact or ""3"" Normal"
     IDS_CMD_MINIMIZED       "/minimized\tStart in minimized mode"
     IDS_CMD_NEW             "/new\t\tUse a new instance of the player"
     IDS_CMD_ADD             "/add\t\tAdd ""pathname"" to playlist, can be combined with /open and /play"
     IDS_CMD_RANDOMIZE       "/randomize\tRandomize the playlist"
-    IDS_CMD_VOLUME          "/volume N\tSet Volume, where N is a range from 0 to 100"
     IDS_CMD_REGVID          "/regvid\t\tCreate file associations for video files"
     IDS_CMD_REGAUD          "/regaud\t\tCreate file associations for audio files"
     IDS_CMD_REGPL           "/regpl\t\tCreate file associations for playlist files"
@@ -3652,23 +3677,8 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_CMD_PNS             "/pns ""name""\tSpecify Pan & Scan preset name to use"
-    IDS_CMD_ICONASSOC       "/iconsassoc\tReassociate format icons"
-    IDS_CMD_NOFOCUS         "/nofocus\t\tOpen MPC-HC in background"
-    IDS_CMD_WEBPORT         "/webport N\tStart web interface on specified port"
-    IDS_CMD_DEBUG           "/debug\t\tShow debug information in OSD"
-    IDS_CMD_NOCRASHREPORTER "/nocrashreporter\tDisable the crash reporter"
-    IDS_CMD_SLAVE           "/slave ""hWnd""\tUse MPC-HC as slave"
-    IDS_CMD_HWGPU           "/hwgpu ""index""\tSet the index of the GPU used for hardware decoding.\n\t\tOnly available for CUVID and DXVA2 (copy-back)"
-    IDS_CMD_RESET           "/reset\t\tRestore default settings"
-    IDS_CMD_HELP            "/help /h /?\tShow help about command line switches"
-    IDS_PPAGEADVANCED_SCORE "Threshold value for subtitles score which are going to be automatically downloaded. Higher values means that more accurately matched subtitles will be loaded, lower values could result in incorrect subtitles being loaded, but there is no one perfect value. Pick one that works best for you."
-    IDS_PPAGE_FS_CLN_AUDIO_DELAY "Audio Delay (ms)"
-    IDS_PPAGEADVANCED_DEFAULTTOOLBARSIZE 
-                            "Size in pixels of the default toolbar."
-    IDS_PPAGEADVANCED_USE_LEGACY_TOOLBAR 
-                            "Use legacy toolbar instead of new vectorized one."
-    IDS_SUBMENU_COPYURL     "Copy URL"
+    IDS_PPAGEADVANCED_SNAPSHOT_NAME_FORMAT 
+                            "Filename format used for snapshots on ""Save Image"". %f is the video filename, %t is the current video position, %Y, %m, %d is the current year, month, day, etc."
 END
 
 #endif    // English (United States) resources

--- a/src/mpc-hc/mpc-hc.rc
+++ b/src/mpc-hc/mpc-hc.rc
@@ -3678,7 +3678,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PPAGEADVANCED_SNAPSHOT_NAME_FORMAT 
-                            "Filename format used for snapshots on ""Save Image"". %f is the video filename, %t is the current video position, %Y, %m, %d is the current year, month, day, etc."
+                            "Filename template that is used for snapshots on ""Save Image"". For example: ""%f_snapshot_%t_[%Y.%m.%d_%H.%M.%S]"", where %f equals video file name, %t current video timestamp, %Y current year, etc."
 END
 
 #endif    // English (United States) resources

--- a/src/mpc-hc/resource.h
+++ b/src/mpc-hc/resource.h
@@ -585,6 +585,7 @@
 #define IDD_SAVEIMAGEDIALOGTEMPL        20015
 #define IDD_CMD_LINE_HELP               20016
 #define IDD_CRASH_REPORTER              20017
+#define IDS_PPAGEADVANCED_SNAPSHOT_NAME_FORMAT 20018
 #define IDI_OPENSUBTITLES               21001
 #define IDI_PODNAPISI                   21002
 #define IDI_SUBDB                       21003
@@ -1577,7 +1578,7 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        20018
+#define _APS_NEXT_RESOURCE_VALUE        20019
 #define _APS_NEXT_COMMAND_VALUE         33452
 #define _APS_NEXT_CONTROL_VALUE         22086
 #define _APS_NEXT_SYMED_VALUE           24044


### PR DESCRIPTION
This adds an option in advanced settings to allow users to customize the default filename used for snapshots when using File > Save Image (or pressing F5). Currently snapshot filenames are hardcoded like `video.mkv_snapshot_01.12_[2017.08.01_16.59.08]`. This option lets users choose their own filename format string, defaulted to `%f_snapshot_%t_[%Y.%m.%d_%H.%M.%S]` to copy current behavior.

Trac: https://trac.mpc-hc.org/ticket/4241
