### PR TITLE
Update Compilation.md.

### DIFF
--- a/docs/Compilation.md
+++ b/docs/Compilation.md
@@ -12,7 +12,7 @@ Choose `Use Git from the Windows command prompt`. This isn't mandatory, so if yo
 ### Visual Studio 2017 or 2015
 
 1. Install Visual C++, part of Visual Studio (any edition will work fine).
-   Make sure to select **Windows 8.1 SDK** and **MFC and ATL support** during installation.
+   Make sure to select **Windows 8.1 SDK**, **MFC and ATL support**, and **Windows Universal CRT SDK** during installation.
 2. Make sure you have installed all available updates from Microsoft Update
 3. Install the DirectX SDK (June 2010) → <https://go.microsoft.com/fwlink/?LinkID=71193>
 


### PR DESCRIPTION
Following _Compilation.md_, MPC-HC was unable to compile, with many missing includes, in Windows 10/Visual Studio 2017 until I selected **Windows Universal CRT SDK** under "Individual Components -> Compilers, build tools, and runtimes". Selecting and ensuring that **Windows Universal CRT SDK** allowed compilation without issues.