### PR TITLE
Shorten tooltip width in Internal Filters

### DIFF
--- a/src/mpc-hc/PPageInternalFilters.cpp
+++ b/src/mpc-hc/PPageInternalFilters.cpp
@@ -75,7 +75,7 @@ BOOL CPPageInternalFiltersListBox::OnToolTipNotify(UINT id, NMHDR* pNMHDR, LRESU
         return FALSE;
     }
 
-    ::SendMessage(pNMHDR->hwndFrom, TTM_SETMAXTIPWIDTH, 0, 1000);
+    ::SendMessage(pNMHDR->hwndFrom, TTM_SETMAXTIPWIDTH, 0, 300);
 
     static CString strTipText; // static string
     strTipText.LoadString(f->nHintID);


### PR DESCRIPTION
"IDS_INTERNAL_LAVF_WMV" is missing line breaks
https://trac.mpc-hc.org/ticket/5905#comment:4