### PR TITLE
Saves without extension overwrites bugfix

### DIFF
--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -5005,7 +5005,7 @@ void CMainFrame::OnFileSaveThumbnails()
     }
     psrc.Combine(s.strSnapshotPath, MakeSnapshotFileName(prefix));
 
-    CSaveThumbnailsDialog fd(s.nJpegQuality, s.iThumbRows, s.iThumbCols, s.iThumbWidth, nullptr, (LPCTSTR)psrc,
+    CSaveThumbnailsDialog fd(s.nJpegQuality, s.iThumbRows, s.iThumbCols, s.iThumbWidth, _T("png"), (LPCTSTR)psrc,
                              _T("BMP - Windows Bitmap (*.bmp)|*.bmp|JPG - JPEG Image (*.jpg)|*.jpg|PNG - Portable Network Graphics (*.png)|*.png||"), GetModalParent());
 
     if (s.strSnapshotExt == _T(".bmp")) {

--- a/src/mpc-hc/MainFrm.cpp
+++ b/src/mpc-hc/MainFrm.cpp
@@ -4909,7 +4909,7 @@ void CMainFrame::OnFileSaveImage()
     }
     psrc.Combine(s.strSnapshotPath, MakeSnapshotFileName(prefix));
 
-    CSaveImageDialog fd(s.nJpegQuality, nullptr, (LPCTSTR)psrc,
+    CSaveImageDialog fd(s.nJpegQuality, _T("jpg"), (LPCTSTR)psrc,
                         _T("BMP - Windows Bitmap (*.bmp)|*.bmp|JPG - JPEG Image (*.jpg)|*.jpg|PNG - Portable Network Graphics (*.png)|*.png||"), GetModalParent());
 
     if (s.strSnapshotExt == _T(".bmp")) {


### PR DESCRIPTION
https://trac.mpc-hc.org/ticket/5877#comment:5
"Save Image" (fixed)
"Save Thumbnails" (fixed)
"Save a Copy"
"Save As" Playlist