### PR TITLE
Make player.html video more responsive

### DIFF
--- a/src/mpc-hc/res/web/javascript.js
+++ b/src/mpc-hc/res/web/javascript.js
@@ -489,12 +489,12 @@ function loadSnapshot() {
 
 function onLoadSnapshot() {
     "use strict";
-    setTimeout(loadSnapshot, 5000);
+    setTimeout(loadSnapshot, 125);
 }
 
 function onAbortErrorSnapshot() {
     "use strict";
-    setTimeout(loadSnapshot, 10000);
+    setTimeout(loadSnapshot, 5000);
 }
 
 function onSeek(e) {


### PR DESCRIPTION
Until some proper technology is used, this change would make the video a bit more responsive.

The change is small enough, so that browser CPU utilization is kept below 7% on average (while the normal is about 3-4% on i5-4430). 50ms delay would make the video more stable, but CPU usage would be double.